### PR TITLE
Expand power-of-two division coverage in int256 benchmarks

### DIFF
--- a/bench/compare_int256.cpp
+++ b/bench/compare_int256.cpp
@@ -174,6 +174,48 @@ static void DivMixed(benchmark::State & state)
     }
 }
 
+template <typename Int>
+static void DivPow2(benchmark::State & state)
+{
+    Int a = (Int{1} << 255) - Int{1};
+    Int b = (Int{1} << 128);
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
+        auto c = a / b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void DivPow2NegDiv(benchmark::State & state)
+{
+    Int a = (Int{1} << 255) - Int{1};
+    Int b = -(Int{1} << 128);
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
+        auto c = a / b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
+template <typename Int>
+static void DivPow2NegBoth(benchmark::State & state)
+{
+    Int a = -((Int{1} << 255) - Int{1});
+    Int b = -(Int{1} << 128);
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
+        auto c = a / b;
+        benchmark::DoNotOptimize(c);
+    }
+}
+
 int main(int argc, char ** argv)
 {
     benchmark::RegisterBenchmark("Add/Small/Wide", &AddSmall<WInt>);
@@ -203,6 +245,12 @@ int main(int argc, char ** argv)
     benchmark::RegisterBenchmark("Div/Large/Boost", &DivLarge<BInt>);
     benchmark::RegisterBenchmark("Div/Mixed/Wide", &DivMixed<WInt>);
     benchmark::RegisterBenchmark("Div/Mixed/Boost", &DivMixed<BInt>);
+    benchmark::RegisterBenchmark("Div/Pow2/Wide", &DivPow2<WInt>);
+    benchmark::RegisterBenchmark("Div/Pow2/Boost", &DivPow2<BInt>);
+    benchmark::RegisterBenchmark("Div/Pow2NegDiv/Wide", &DivPow2NegDiv<WInt>);
+    benchmark::RegisterBenchmark("Div/Pow2NegDiv/Boost", &DivPow2NegDiv<BInt>);
+    benchmark::RegisterBenchmark("Div/Pow2NegBoth/Wide", &DivPow2NegBoth<WInt>);
+    benchmark::RegisterBenchmark("Div/Pow2NegBoth/Boost", &DivPow2NegBoth<BInt>);
 
     benchmark::Initialize(&argc, argv);
     benchmark::RunSpecifiedBenchmarks();

--- a/bench/compare_int256_random.cpp
+++ b/bench/compare_int256_random.cpp
@@ -176,6 +176,42 @@ struct DivMixedGen
     }
 };
 
+template <typename Int>
+struct DivPow2Gen
+{
+    std::pair<Int, Int> operator()(std::mt19937_64 & rng) const
+    {
+        std::uniform_int_distribution<uint64_t> dist;
+        Int a = (Int{1} << 255) - Int(dist(rng));
+        Int b = (Int{1} << 128);
+        return {a, b};
+    }
+};
+
+template <typename Int>
+struct DivPow2NegDivGen
+{
+    std::pair<Int, Int> operator()(std::mt19937_64 & rng) const
+    {
+        std::uniform_int_distribution<uint64_t> dist;
+        Int a = (Int{1} << 255) - Int(dist(rng));
+        Int b = -(Int{1} << 128);
+        return {a, b};
+    }
+};
+
+template <typename Int>
+struct DivPow2NegBothGen
+{
+    std::pair<Int, Int> operator()(std::mt19937_64 & rng) const
+    {
+        std::uniform_int_distribution<uint64_t> dist;
+        Int a = -((Int{1} << 255) - Int(dist(rng)));
+        Int b = -(Int{1} << 128);
+        return {a, b};
+    }
+};
+
 template <typename Int, template <typename> class Gen>
 static std::vector<std::pair<Int, Int>> generate_inputs(uint64_t seed)
 {
@@ -230,6 +266,9 @@ int main(int argc, char ** argv)
     run_case<DivSmallGen>("Div/Small", [](const auto & x, const auto & y) { return x / y; }, 10);
     run_case<DivLargeGen>("Div/Large", [](const auto & x, const auto & y) { return x / y; }, 11);
     run_case<DivMixedGen>("Div/Mixed", [](const auto & x, const auto & y) { return x / y; }, 12);
+    run_case<DivPow2Gen>("Div/Pow2", [](const auto & x, const auto & y) { return x / y; }, 13);
+    run_case<DivPow2NegDivGen>("Div/Pow2NegDiv", [](const auto & x, const auto & y) { return x / y; }, 14);
+    run_case<DivPow2NegBothGen>("Div/Pow2NegBoth", [](const auto & x, const auto & y) { return x / y; }, 15);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- benchmark negative power-of-two divisors to cover all sign combinations in int256 division
- extend randomized benchmarks with matching generators for power-of-two divisors

## Testing
- `cmake -S . -B build -DGINT_BUILD_TESTS=ON -DGINT_BUILD_BENCHMARKS=ON`
- `cmake --build build --config Debug`
- `cd build && ctest --output-on-failure`
- `./perf_compare_int256`
- `./perf_compare_int256_random`


------
https://chatgpt.com/codex/tasks/task_e_68a9e65e3d74832990c7aa2bdf8f9a08