### PR TITLE
Handle lcov compatibility across versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,8 @@ jobs:
           ctest --output-on-failure || true
       - name: Generate coverage
         run: |
-          lcov --capture --directory build --output-file coverage.info --ignore-errors mismatch
+          IGNORE_ERRORS=$(geninfo --help 2>&1 | grep -q 'inconsistent' && echo '--ignore-errors inconsistent' || echo '--ignore-errors mismatch')
+          lcov --capture --directory build --output-file coverage.info $IGNORE_ERRORS
           lcov --remove coverage.info '/usr/*' '*/tests/*' --output-file coverage.info
           lcov --list coverage.info
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,12 @@ $(BENCH_BUILD_DIR)/Makefile:
 $(COVERAGE_DIR)/Makefile:
 	cmake -S . -B $(COVERAGE_DIR) -DENABLE_COVERAGE=ON -DGINT_BUILD_TESTS=ON -DGINT_BUILD_BENCHMARKS=OFF
 
-LCOV_IGNORE_MISMATCH := $(shell geninfo --help 2>&1 | grep -q 'mismatch' && echo '--ignore-errors mismatch')
+LCOV_IGNORE_ERRORS := $(shell \
+    if geninfo --help 2>&1 | grep -q 'inconsistent'; then \
+        echo '--ignore-errors inconsistent'; \
+    elif geninfo --help 2>&1 | grep -q 'mismatch'; then \
+        echo '--ignore-errors mismatch'; \
+    fi)
 
 # Build and run unit tests
 test: $(TEST_BUILD_DIR)/Makefile
@@ -30,7 +35,7 @@ bench: $(BENCH_BUILD_DIR)/Makefile
 coverage: $(COVERAGE_DIR)/Makefile
 	cmake --build $(COVERAGE_DIR) --config Debug
 	cd $(COVERAGE_DIR) && ctest --output-on-failure
-	lcov --capture --directory $(COVERAGE_DIR) --output-file $(COVERAGE_DIR)/coverage.info $(LCOV_IGNORE_MISMATCH)
+	lcov --capture --directory $(COVERAGE_DIR) --output-file $(COVERAGE_DIR)/coverage.info $(LCOV_IGNORE_ERRORS)
 	lcov --remove $(COVERAGE_DIR)/coverage.info '/usr/*' '*/tests/*' --output-file $(COVERAGE_DIR)/coverage.info
 	lcov --list $(COVERAGE_DIR)/coverage.info
 


### PR DESCRIPTION
## Summary
- adapt lcov coverage generation for both `mismatch` and `inconsistent` ignore flags
- apply the same detection in local Makefile and CI workflow

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68abecbc6fbc8329836538f38107b04d