### PR TITLE
Fix division by wide limb values

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -815,7 +815,12 @@ public:
         return result;
     }
 
-    friend integer operator/(integer lhs, limb_type rhs) noexcept { return lhs / static_cast<signed_limb_type>(rhs); }
+    friend integer operator/(integer lhs, limb_type rhs) noexcept
+    {
+        if (rhs <= static_cast<limb_type>(std::numeric_limits<signed_limb_type>::max()))
+            return lhs / static_cast<signed_limb_type>(rhs);
+        return lhs / integer(rhs);
+    }
 
     friend integer operator/(integer lhs, signed_limb_type rhs) noexcept
     {
@@ -834,7 +839,12 @@ public:
         return lhs;
     }
 
-    friend integer operator%(integer lhs, limb_type rhs) noexcept { return lhs % static_cast<signed_limb_type>(rhs); }
+    friend integer operator%(integer lhs, limb_type rhs) noexcept
+    {
+        if (rhs <= static_cast<limb_type>(std::numeric_limits<signed_limb_type>::max()))
+            return lhs % static_cast<signed_limb_type>(rhs);
+        return lhs % integer(rhs);
+    }
 
     friend integer operator%(integer lhs, signed_limb_type rhs) noexcept
     {
@@ -848,7 +858,8 @@ public:
     template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
     friend integer operator/(integer lhs, T rhs) noexcept
     {
-        if (sizeof(T) <= sizeof(limb_type))
+        if (sizeof(T) <= sizeof(limb_type)
+            && (!std::is_unsigned<T>::value || rhs <= static_cast<T>(std::numeric_limits<signed_limb_type>::max())))
             return lhs / static_cast<signed_limb_type>(rhs);
         return lhs / integer(rhs);
     }
@@ -878,7 +889,8 @@ public:
     template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
     friend integer operator%(integer lhs, T rhs) noexcept
     {
-        if (sizeof(T) <= sizeof(limb_type))
+        if (sizeof(T) <= sizeof(limb_type)
+            && (!std::is_unsigned<T>::value || rhs <= static_cast<T>(std::numeric_limits<signed_limb_type>::max())))
         {
             integer q;
             signed_limb_type r = lhs.div_mod_small(static_cast<signed_limb_type>(rhs), q);

--- a/tests/gint_test.cpp
+++ b/tests/gint_test.cpp
@@ -52,6 +52,26 @@ TEST(WideIntegerOps, SmallMulDiv)
     EXPECT_EQ((c * 7ULL) / 7ULL, c);
 }
 
+TEST(WideIntegerOps, LargeLimbDivMod)
+{
+    using UInt256 = gint::integer<256, unsigned>;
+    UInt256 u = UInt256(1);
+    u <<= 64;
+    uint64_t div = 1ULL << 63;
+    EXPECT_EQ(u / div, UInt256(2));
+    EXPECT_EQ(u % div, UInt256(0));
+
+    using Int256 = gint::integer<256, signed>;
+    Int256 s = Int256(1);
+    s <<= 64;
+    EXPECT_EQ(s / div, Int256(2));
+    EXPECT_EQ(s % div, Int256(0));
+
+    s = -s;
+    EXPECT_EQ(s / div, Int256(-2));
+    EXPECT_EQ(s % div, Int256(0));
+}
+
 TEST(WideIntegerOps, SignedSmallDivMod)
 {
     using Int256 = gint::integer<256, signed>;


### PR DESCRIPTION
## Summary
- handle divisors larger than 2^63 without signed overflow
- add regression test for dividing by large 64-bit limbs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68ac34d824588329830e9edb036e67f2