### PR TITLE
Refactor 128-bit division path

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -768,11 +768,7 @@ public:
             else if (limbs == 2)
             {
                 // both operands are 128-bit wide
-                unsigned __int128 a = (static_cast<unsigned __int128>(lhs.data_[1]) << 64) | lhs.data_[0];
-                unsigned __int128 b = (static_cast<unsigned __int128>(divisor.data_[1]) << 64) | divisor.data_[0];
-                unsigned __int128 q = a / b;
-                result.data_[0] = static_cast<limb_type>(q);
-                result.data_[1] = static_cast<limb_type>(q >> 64);
+                result = div_128(lhs, divisor);
             }
             else if (divisor_limbs <= 2)
             {
@@ -782,11 +778,7 @@ public:
                 if (lhs_limbs <= 2)
                 {
                     // operands fit into two limbs; reuse the 128-bit path
-                    unsigned __int128 a = (static_cast<unsigned __int128>(lhs.data_[1]) << 64) | lhs.data_[0];
-                    unsigned __int128 b = (static_cast<unsigned __int128>(divisor.data_[1]) << 64) | divisor.data_[0];
-                    unsigned __int128 q = a / b;
-                    result.data_[0] = static_cast<limb_type>(q);
-                    result.data_[1] = static_cast<limb_type>(q >> 64);
+                    result = div_128(lhs, divisor);
                 }
                 else if (limbs <= 4)
                 {
@@ -1264,6 +1256,26 @@ private:
             }
         }
         return found;
+    }
+
+    template <size_t L = limbs>
+    static typename std::enable_if<(L >= 2), integer>::type div_128(const integer & lhs, const integer & rhs) noexcept
+    {
+        unsigned __int128 a = (static_cast<unsigned __int128>(lhs.data_[1]) << 64) | lhs.data_[0];
+        unsigned __int128 b = (static_cast<unsigned __int128>(rhs.data_[1]) << 64) | rhs.data_[0];
+        unsigned __int128 q = a / b;
+        integer result;
+        result.data_[0] = static_cast<limb_type>(q);
+        result.data_[1] = static_cast<limb_type>(q >> 64);
+        return result;
+    }
+
+    template <size_t L = limbs>
+    static typename std::enable_if<(L < 2), integer>::type div_128(const integer & lhs, const integer & rhs) noexcept
+    {
+        integer result;
+        result.data_[0] = lhs.data_[0] / rhs.data_[0];
+        return result;
     }
 
     static integer div_shift_subtract(integer lhs, integer divisor) noexcept

--- a/tests/gint_test.cpp
+++ b/tests/gint_test.cpp
@@ -944,6 +944,13 @@ TEST(WideIntegerDivModSmall, SingleLimbZero)
     EXPECT_EQ(z / 5, U64(0));
 }
 
+TEST(WideIntegerDivModSmall, SingleLimbBasic)
+{
+    using U64 = gint::integer<64, unsigned>;
+    U64 v = 123456789ULL;
+    EXPECT_EQ(v / 3, U64(41152263ULL));
+}
+
 TEST(WideIntegerDivModSmall, MultiLimbZero)
 {
     using U256 = gint::integer<256, unsigned>;


### PR DESCRIPTION
## Summary
- isolate 128-bit division in a helper guarded by SFINAE
- exercise single-limb division with a new unit test

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68ac602644ec8329b33e57293d85a8e5