### PR TITLE
Fix overflow in shift operations

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -459,8 +459,16 @@ public:
     {
         if (n <= 0)
             return *this;
-        size_t limb_shift = static_cast<size_t>(n) / 64;
-        int bit_shift = n % 64;
+        size_t total_bits = limbs * 64;
+        size_t shift = static_cast<size_t>(n);
+        if (shift >= total_bits)
+        {
+            for (size_t i = 0; i < limbs; ++i)
+                data_[i] = 0;
+            return *this;
+        }
+        size_t limb_shift = shift / 64;
+        int bit_shift = shift % 64;
         if (limb_shift)
         {
             for (size_t i = limbs; i-- > limb_shift;)
@@ -485,8 +493,16 @@ public:
     {
         if (n <= 0)
             return *this;
-        size_t limb_shift = static_cast<size_t>(n) / 64;
-        int bit_shift = n % 64;
+        size_t total_bits = limbs * 64;
+        size_t shift = static_cast<size_t>(n);
+        if (shift >= total_bits)
+        {
+            for (size_t i = 0; i < limbs; ++i)
+                data_[i] = 0;
+            return *this;
+        }
+        size_t limb_shift = shift / 64;
+        int bit_shift = shift % 64;
         if (limb_shift)
         {
             for (size_t i = 0; i < limbs - limb_shift; ++i)

--- a/tests/gint_test.cpp
+++ b/tests/gint_test.cpp
@@ -855,6 +855,34 @@ TEST(WideIntegerShift, NonPositive)
     EXPECT_EQ(b, a);
 }
 
+TEST(WideIntegerShift, LargeShiftAmounts)
+{
+    using U256 = gint::integer<256, unsigned>;
+    U256 v = U256(1) << 128;
+
+    U256 tmp = v;
+    tmp <<= 256;
+    EXPECT_EQ(tmp, U256(0));
+    tmp = v;
+    tmp <<= 320;
+    EXPECT_EQ(tmp, U256(0));
+
+    tmp = v;
+    tmp >>= 256;
+    EXPECT_EQ(tmp, U256(0));
+    tmp = v;
+    tmp >>= 320;
+    EXPECT_EQ(tmp, U256(0));
+
+    using U128 = gint::integer<128, unsigned>;
+    U128 small = U128(1);
+    small <<= 192;
+    EXPECT_EQ(small, U128(0));
+    small = U128(1);
+    small >>= 192;
+    EXPECT_EQ(small, U128(0));
+}
+
 TEST(WideIntegerConversion, LongDoubleZero)
 {
     gint::integer<128, signed> z = 0;


### PR DESCRIPTION
## Summary
- avoid out-of-bounds writes when shifting by more than the integer width
- test large shift counts on wide integers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68ac7a43a9108329b25d5d018ce23bbb