### PR TITLE
Make division-by-zero checks optional via macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ int main() {
 }
 ```
 
+## Edge Case Behavior
+
+gint defines deterministic results for several potentially surprising scenarios:
+
+* Constructing an unsigned wide integer from a negative value wraps modulo its bit width.
+* Unsigned subtraction underflow wraps around as in standard two's-complement arithmetic.
+* Bitwise operations on negative values operate on their two's-complement representation.
+* Division or modulo by zero throws `std::domain_error` only when
+  `GINT_ENABLE_DIVZERO_CHECKS` is defined; otherwise no check is performed.
+
 ## Building Tests
 
 ```bash

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -19,6 +19,19 @@
 #    define GINT_UNLIKELY(x) (x)
 #endif
 
+#if defined(GINT_ENABLE_DIVZERO_CHECKS)
+#    define GINT_ZERO_CHECK(cond, msg) \
+        do \
+        { \
+            if (GINT_UNLIKELY(cond)) \
+                throw std::domain_error(msg); \
+        } while (false)
+#else
+#    define GINT_ZERO_CHECK(cond, msg) ((void)0)
+#endif
+#define GINT_DIVZERO_CHECK(cond) GINT_ZERO_CHECK(cond, "division by zero")
+#define GINT_MODZERO_CHECK(cond) GINT_ZERO_CHECK(cond, "modulo by zero")
+
 namespace gint
 {
 
@@ -774,8 +787,7 @@ public:
         size_t divisor_limbs = limbs;
         while (divisor_limbs > 0 && divisor.data_[divisor_limbs - 1] == 0)
             --divisor_limbs;
-        if (GINT_UNLIKELY(divisor_limbs == 0))
-            throw std::domain_error("division by zero");
+        GINT_DIVZERO_CHECK(divisor_limbs == 0);
         bool small_divisor = divisor_limbs == 1;
         if (small_divisor)
         {
@@ -834,8 +846,7 @@ public:
 
     friend integer operator/(integer lhs, limb_type rhs)
     {
-        if (GINT_UNLIKELY(rhs == 0))
-            throw std::domain_error("division by zero");
+        GINT_DIVZERO_CHECK(rhs == 0);
         if (rhs <= static_cast<limb_type>(std::numeric_limits<signed_limb_type>::max()))
             return lhs / static_cast<signed_limb_type>(rhs);
         return lhs / integer(rhs);
@@ -843,8 +854,7 @@ public:
 
     friend integer operator/(integer lhs, signed_limb_type rhs)
     {
-        if (GINT_UNLIKELY(rhs == 0))
-            throw std::domain_error("division by zero");
+        GINT_DIVZERO_CHECK(rhs == 0);
         integer q;
         lhs.div_mod_small(rhs, q);
         return q;
@@ -854,8 +864,7 @@ public:
 
     friend integer operator%(integer lhs, const integer & rhs)
     {
-        if (GINT_UNLIKELY(rhs.is_zero()))
-            throw std::domain_error("modulo by zero");
+        GINT_MODZERO_CHECK(rhs.is_zero());
         integer q = lhs / rhs;
         q *= rhs;
         lhs -= q;
@@ -864,8 +873,7 @@ public:
 
     friend integer operator%(integer lhs, limb_type rhs)
     {
-        if (GINT_UNLIKELY(rhs == 0))
-            throw std::domain_error("modulo by zero");
+        GINT_MODZERO_CHECK(rhs == 0);
         if (rhs <= static_cast<limb_type>(std::numeric_limits<signed_limb_type>::max()))
             return lhs % static_cast<signed_limb_type>(rhs);
         return lhs % integer(rhs);
@@ -873,8 +881,7 @@ public:
 
     friend integer operator%(integer lhs, signed_limb_type rhs)
     {
-        if (GINT_UNLIKELY(rhs == 0))
-            throw std::domain_error("modulo by zero");
+        GINT_MODZERO_CHECK(rhs == 0);
         integer q;
         signed_limb_type r = lhs.div_mod_small(rhs, q);
         return integer(r);
@@ -885,8 +892,7 @@ public:
     template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
     friend integer operator/(integer lhs, T rhs)
     {
-        if (GINT_UNLIKELY(rhs == 0))
-            throw std::domain_error("division by zero");
+        GINT_DIVZERO_CHECK(rhs == 0);
         if (sizeof(T) <= sizeof(limb_type)
             && (!std::is_unsigned<T>::value || rhs <= static_cast<T>(std::numeric_limits<signed_limb_type>::max())))
             return lhs / static_cast<signed_limb_type>(rhs);
@@ -902,8 +908,7 @@ public:
     template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
     friend integer operator/(integer lhs, T rhs)
     {
-        if (GINT_UNLIKELY(rhs == 0))
-            throw std::domain_error("division by zero");
+        GINT_DIVZERO_CHECK(rhs == 0);
         long double res = static_cast<long double>(lhs);
         res /= static_cast<long double>(rhs);
         return integer(res);
@@ -912,8 +917,7 @@ public:
     template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
     friend integer operator/(T lhs, integer rhs)
     {
-        if (GINT_UNLIKELY(rhs.is_zero()))
-            throw std::domain_error("division by zero");
+        GINT_DIVZERO_CHECK(rhs.is_zero());
         long double res = static_cast<long double>(lhs);
         res /= static_cast<long double>(rhs);
         return integer(res);
@@ -922,8 +926,7 @@ public:
     template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
     friend integer operator%(integer lhs, T rhs)
     {
-        if (GINT_UNLIKELY(rhs == 0))
-            throw std::domain_error("modulo by zero");
+        GINT_MODZERO_CHECK(rhs == 0);
         if (sizeof(T) <= sizeof(limb_type)
             && (!std::is_unsigned<T>::value || rhs <= static_cast<T>(std::numeric_limits<signed_limb_type>::max())))
         {
@@ -943,8 +946,7 @@ public:
     template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
     friend integer operator%(integer lhs, T rhs)
     {
-        if (GINT_UNLIKELY(rhs == 0))
-            throw std::domain_error("modulo by zero");
+        GINT_MODZERO_CHECK(rhs == 0);
         return lhs % integer(rhs);
     }
 

--- a/tests/compile_test.cpp
+++ b/tests/compile_test.cpp
@@ -1,6 +1,20 @@
 #include <gint/gint.h>
 #include <gtest/gtest.h>
 
+#if defined(GINT_ENABLE_DIVZERO_CHECKS)
+#    error "GINT_ENABLE_DIVZERO_CHECKS should be undefined by default"
+#endif
+
+// Ensure division by zero compiles when checks are disabled.
+static void division_no_check()
+{
+    using U256 = gint::integer<256, unsigned>;
+    U256 one = 1;
+    U256 zero = 0;
+    auto res = one / zero; // NOLINT: intentional UB if executed
+    (void)res;
+}
+
 TEST(CompileTest, Basic)
 {
     gint::integer<128, unsigned> x = 42;

--- a/tests/gint_test.cpp
+++ b/tests/gint_test.cpp
@@ -5,6 +5,7 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#define GINT_ENABLE_DIVZERO_CHECKS
 #include <gint/gint.h>
 
 struct A
@@ -1072,4 +1073,26 @@ TEST(WideIntegerShift, Boundary)
     EXPECT_EQ(v >> 256, U256(0));
     EXPECT_EQ(v << -1, v);
     EXPECT_EQ(v >> -1, v);
+}
+
+TEST(WideIntegerExceptions, ConstructFromNegative)
+{
+    gint::integer<128, unsigned> u = -1;
+    EXPECT_EQ(gint::to_string(u), "340282366920938463463374607431768211455");
+}
+
+TEST(WideIntegerExceptions, UnsignedSubtractionUnderflow)
+{
+    gint::integer<128, unsigned> a = 5;
+    gint::integer<128, unsigned> b = 10;
+    auto c = a - b;
+    EXPECT_EQ(gint::to_string(c), "340282366920938463463374607431768211451");
+}
+
+TEST(WideIntegerExceptions, BitwiseOnNegative)
+{
+    gint::integer<128, signed> a = -5;
+    gint::integer<128, signed> b = 3;
+    auto c = a & b;
+    EXPECT_EQ(gint::to_string(c), "3");
 }


### PR DESCRIPTION
## Summary
- gate division and modulo by zero checks behind `GINT_ENABLE_DIVZERO_CHECKS`
- document opt-in flag
- add tests confirming default-off and guarded behavior
- wrap zero-divisor checks in helper macros to avoid code duplication

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac877971388329bb01d7a12acf05e8