### PR TITLE
Fix __int128 construction sign handling

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -320,9 +320,9 @@ private:
     template <typename T, size_t I>
     static constexpr limb_type limb_from(T v) noexcept
     {
-        return I < (sizeof(T) * 8 + 63) / 64
-            ? static_cast<limb_type>((std::is_signed<T>::value ? static_cast<__int128>(v) : static_cast<unsigned __int128>(v)) >> (I * 64))
-            : (std::is_signed<T>::value && v < 0 ? ~0ULL : 0ULL);
+        // Cast to unsigned before shifting to avoid implementation-defined behavior
+        return I < ((sizeof(T) * 8 + 63) / 64) ? static_cast<limb_type>(static_cast<unsigned __int128>(v) >> (I * 64))
+                                               : ((std::is_signed<T>::value && v < 0) ? ~0ULL : 0ULL);
     }
 
 public:

--- a/tests/gint_test.cpp
+++ b/tests/gint_test.cpp
@@ -401,6 +401,21 @@ TEST(WideIntegerConversion, Int128)
     EXPECT_TRUE(c == u);
     EXPECT_TRUE(u == c);
 }
+
+TEST(WideIntegerConversion, NegativeInt128)
+{
+    __int128 neg = -((static_cast<__int128>(1) << 100) + 7);
+    gint::integer<128, signed> a = neg;
+    EXPECT_EQ(static_cast<__int128>(a), neg);
+}
+TEST(WideIntegerConversion, ConstexprNegativeInt128)
+{
+    constexpr __int128 neg = -((static_cast<__int128>(1) << 100) + 7);
+    constexpr gint::integer<128, signed> a = neg;
+    static_assert(a == gint::integer<128, signed>(neg), "value mismatch");
+    (void)a;
+}
+
 #endif
 
 TEST(WideIntegerBoundary, Unsigned256)


### PR DESCRIPTION
## Summary
- avoid implementation-defined signed shifts when decomposing values
- handle negative `__int128` using a single return expression for C++11 constexpr
- add runtime and `constexpr` regression tests for constructing from negative `__int128`
- document unsigned cast in limb extraction

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ad11eb82008329a900e3c996f2561a