### PR TITLE
Fix conditional conversion ambiguity

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -355,7 +355,7 @@ public:
 
     // Conversion operators
     template <typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
-    operator T() const noexcept
+    explicit operator T() const noexcept
     {
         unsigned __int128 value = 0;
         for (size_t i = 0; i < limbs && i < (sizeof(T) + sizeof(limb_type) - 1) / sizeof(limb_type); ++i)
@@ -384,7 +384,7 @@ public:
     //
     // Note: keep as a concrete conversion specifically to provide a stable route
     // for contexts where no target type is implied.
-    operator __int128() const noexcept
+    explicit operator __int128() const noexcept
     {
         unsigned __int128 value = 0;
         for (size_t i = 0; i < limbs && i < (sizeof(__int128) + sizeof(limb_type) - 1) / sizeof(limb_type); ++i)
@@ -392,7 +392,7 @@ public:
         return static_cast<__int128>(value);
     }
 
-    operator unsigned __int128() const noexcept
+    explicit operator unsigned __int128() const noexcept
     {
         unsigned __int128 value = 0;
         for (size_t i = 0; i < limbs && i < (sizeof(unsigned __int128) + sizeof(limb_type) - 1) / sizeof(limb_type); ++i)


### PR DESCRIPTION
## Summary
- make conversions from `gint::integer` to builtin types explicit
- add compile-time check that `const Int256` doesn't implicitly convert to `int`
- adjust conditional expression tests to use `const Int256`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aed0d1910083299a3f0aabb728a7e7