### PR TITLE
fix macOS CI brew cmake conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
               libfmt-dev libgtest-dev libboost-dev
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
             brew update
+            brew uninstall --ignore-dependencies cmake || true
             brew install cmake clang-format fmt googletest boost
           fi
       - name: Configure


### PR DESCRIPTION
## Summary
- uninstall preinstalled cmake before installing dependencies on macOS

## Testing
- `cmake -S . -B build -DGINT_BUILD_TESTS=ON -DGINT_BUILD_BENCHMARKS=OFF`
- `cmake --build build --config Debug`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aeefa686ec8329b18100b755518bed