### PR TITLE
Add overflow boundary tests

### DIFF
--- a/tests/gint_test.cpp
+++ b/tests/gint_test.cpp
@@ -1127,3 +1127,42 @@ TEST(WideIntegerExceptions, BitwiseOnNegative)
     auto c = a & b;
     EXPECT_EQ(gint::to_string(c), "3");
 }
+TEST(WideIntegerOverflow, UnsignedAdditionWrap)
+{
+    using U128 = gint::integer<128, unsigned>;
+    U128 max = U128(-1);
+    U128 result = max + U128(1);
+    EXPECT_EQ(result, U128(0));
+}
+
+TEST(WideIntegerOverflow, SignedMultiplicationWrap)
+{
+    using S128 = gint::integer<128, signed>;
+    S128 max = (S128(1) << 127) - S128(1);
+    S128 result = max * 2;
+    EXPECT_EQ(result, S128(-2));
+}
+
+TEST(WideIntegerConversionOverflow, ToUint64)
+{
+    using U256 = gint::integer<256, unsigned>;
+    U256 val = (U256(1) << 200) + 123456789ULL;
+    uint64_t truncated = static_cast<uint64_t>(val);
+    EXPECT_EQ(truncated, 123456789ULL);
+}
+
+TEST(WideIntegerConversionOverflow, ToInt64)
+{
+    using S256 = gint::integer<256, signed>;
+    S256 val = (S256(1) << 200) + (S256(1) << 63);
+    int64_t truncated = static_cast<int64_t>(val);
+    EXPECT_EQ(truncated, std::numeric_limits<int64_t>::min());
+}
+
+TEST(WideIntegerConversionOverflow, FromLargeNative)
+{
+    using U64 = gint::integer<64, unsigned>;
+    unsigned __int128 big = (static_cast<unsigned __int128>(1) << 100) + 7;
+    U64 v = big;
+    EXPECT_EQ(v, U64(7));
+}


### PR DESCRIPTION
## Summary
- add arithmetic overflow tests for unsigned addition and signed multiplication
- add conversion overflow tests for narrowing to `int64_t` and `uint64_t`
- check assignment from large native integer into narrow wide integer

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aeffd51960832991317d12b212d0dd