### PR TITLE
Fix macOS CI build error caused by Homebrew pinned tap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
             sudo apt-get install -y cmake build-essential clang-format \
               libfmt-dev libgtest-dev libboost-dev
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew update-reset
             brew update
             brew install cmake clang-format fmt googletest boost
           fi


### PR DESCRIPTION
## Summary
- reset Homebrew during macOS CI to avoid pinned tap errors

## Testing
- `apt-get update`
- `apt-get install -y cmake build-essential clang-format libfmt-dev libgtest-dev libboost-dev`
- `cmake -S . -B build -DGINT_BUILD_TESTS=ON -DGINT_BUILD_BENCHMARKS=OFF`
- `cmake --build build --config Debug`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b07131f0708329a2b8d22860b1cd78