### PR TITLE
tests: add coverage gap tests for floating conversions, shifts, and __int128 div/mod

### DIFF
--- a/tests/gint_test.cpp
+++ b/tests/gint_test.cpp
@@ -1024,7 +1024,7 @@ TEST(CoverageGaps, SignedRightShiftWrapper)
 {
     using S128 = gint::integer<128, signed>;
     S128 v = 8;
-    auto r = v >> 2; // calls wrapper which delegates to >>= 
+    auto r = v >> 2; // calls wrapper which delegates to >>=
     EXPECT_EQ(r, S128(2));
 }
 
@@ -1058,8 +1058,8 @@ TEST(CoverageGaps, DivisionIntegralFallbackUnsignedInt128)
     using U256 = gint::integer<256, unsigned>;
     U256 lhs = (U256(1) << 180) + 12345;
     unsigned __int128 big = (static_cast<unsigned __int128>(1) << 100) + 7; // > max signed 64
-    U256 q1 = lhs / big;                 // should go through fallback path
-    U256 q2 = lhs / U256(big);           // integer/integer division
+    U256 q1 = lhs / big; // should go through fallback path
+    U256 q2 = lhs / U256(big); // integer/integer division
     EXPECT_EQ(q1, q2);
 }
 
@@ -1068,7 +1068,7 @@ TEST(CoverageGaps, ModIntegralFallbackUnsignedInt128)
     using U256 = gint::integer<256, unsigned>;
     U256 lhs = (U256(1) << 180) + 98765;
     unsigned __int128 big = (static_cast<unsigned __int128>(1) << 100) + 11;
-    U256 r1 = lhs % big;                 // fallback path
+    U256 r1 = lhs % big; // fallback path
     U256 r2 = lhs % U256(big);
     EXPECT_EQ(r1, r2);
 }


### PR DESCRIPTION
This PR adds tests to increase coverage across several code paths that were previously under-exercised.

What's included
- Exercise long double constructor/assignment and explicit conversions for 128/256-bit integers.
- Cover the signed right-shift wrapper and shift edge cases (shift by 0 and by >= total bit-width) for 512-bit.
- Add a power-of-two division case for signed 256-bit integers.
- Verify the integral-division/modulo fallback paths using unsigned __int128 (value > max signed 64-bit).
- Test floating division both directions (U128 / long double, and long double / U128).
- Minor whitespace tidy in CMakeLists.txt.

Rationale
- Improves line/branch coverage around float interop, shifting wrappers, and integral fallback implementations without changing library behavior.

Notes
- No API or ABI changes. Library sources remain untouched; only tests and a trivial whitespace change in CMake.
- third_party/ is intentionally not included in this PR (local-only).
