### PR TITLE
Add bitwise and comparison benchmarks for int256

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,4 +120,16 @@ if(GINT_BUILD_BENCHMARKS)
     target_compile_definitions(perf_compare_int256_random PRIVATE GINT_ENABLE_FMT)
     target_link_libraries(perf_compare_int256_random PRIVATE fmt::fmt benchmark::benchmark)
     target_compile_options(perf_compare_int256_random PRIVATE -O3 -DNDEBUG)
+
+    # Int256 bitwise and comparison benchmarks
+    add_executable(perf_compare_int256_bit
+        bench/compare_int256_bit.cpp
+    )
+    target_compile_features(perf_compare_int256_bit PRIVATE cxx_std_11)
+    target_include_directories(perf_compare_int256_bit PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_compile_definitions(perf_compare_int256_bit PRIVATE GINT_ENABLE_FMT)
+    target_link_libraries(perf_compare_int256_bit PRIVATE fmt::fmt benchmark::benchmark)
+    target_compile_options(perf_compare_int256_bit PRIVATE -O3 -DNDEBUG)
 endif()

--- a/bench/compare_int256_bit.cpp
+++ b/bench/compare_int256_bit.cpp
@@ -1,0 +1,115 @@
+#include <benchmark/benchmark.h>
+#include <boost/multiprecision/cpp_int.hpp>
+
+#include <gint/gint.h>
+
+using WInt = gint::integer<256, signed>;
+using BInt = boost::multiprecision::int256_t;
+
+// Bitwise operations
+
+template <typename Int>
+static void BitAnd(benchmark::State & state)
+{
+    Int a = (Int{1} << 200) + Int{0x12345678};
+    Int b = (Int{1} << 199) + Int{0x87654321};
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
+        auto c = a & b;
+        benchmark::DoNotOptimize(c);
+        benchmark::ClobberMemory();
+        ++a;
+        ++b;
+    }
+}
+
+template <typename Int>
+static void BitOr(benchmark::State & state)
+{
+    Int a = (Int{1} << 200) + Int{0x12345678};
+    Int b = (Int{1} << 199) + Int{0x87654321};
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
+        auto c = a | b;
+        benchmark::DoNotOptimize(c);
+        benchmark::ClobberMemory();
+        ++a;
+        ++b;
+    }
+}
+
+template <typename Int>
+static void BitXor(benchmark::State & state)
+{
+    Int a = (Int{1} << 200) + Int{0x12345678};
+    Int b = (Int{1} << 199) + Int{0x87654321};
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
+        auto c = a ^ b;
+        benchmark::DoNotOptimize(c);
+        benchmark::ClobberMemory();
+        ++a;
+        ++b;
+    }
+}
+
+// Comparison operations
+
+template <typename Int>
+static void CmpEq(benchmark::State & state)
+{
+    Int a = (Int{1} << 200) + Int{0x12345678};
+    Int b = a;
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
+        bool r = a == b;
+        benchmark::DoNotOptimize(r);
+        benchmark::ClobberMemory();
+        ++a;
+        ++b;
+    }
+}
+
+template <typename Int>
+static void CmpLt(benchmark::State & state)
+{
+    Int a = (Int{1} << 200) + Int{0x12345678};
+    Int b = a + Int{1};
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(a);
+        benchmark::DoNotOptimize(b);
+        bool r = a < b;
+        benchmark::DoNotOptimize(r);
+        benchmark::ClobberMemory();
+        ++a;
+        ++b;
+    }
+}
+
+int main(int argc, char ** argv)
+{
+    benchmark::RegisterBenchmark("Bit/And/Wide", &BitAnd<WInt>);
+    benchmark::RegisterBenchmark("Bit/And/Boost", &BitAnd<BInt>);
+    benchmark::RegisterBenchmark("Bit/Or/Wide", &BitOr<WInt>);
+    benchmark::RegisterBenchmark("Bit/Or/Boost", &BitOr<BInt>);
+    benchmark::RegisterBenchmark("Bit/Xor/Wide", &BitXor<WInt>);
+    benchmark::RegisterBenchmark("Bit/Xor/Boost", &BitXor<BInt>);
+
+    benchmark::RegisterBenchmark("Cmp/Eq/Wide", &CmpEq<WInt>);
+    benchmark::RegisterBenchmark("Cmp/Eq/Boost", &CmpEq<BInt>);
+    benchmark::RegisterBenchmark("Cmp/LT/Wide", &CmpLt<WInt>);
+    benchmark::RegisterBenchmark("Cmp/LT/Boost", &CmpLt<BInt>);
+
+    benchmark::Initialize(&argc, argv);
+    benchmark::RunSpecifiedBenchmarks();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add benchmark suite measuring bitwise and comparison ops against Boost int256
- wire new benchmark into CMake build
- vary operands and clobber memory to prevent benchmarks from being optimized away

## Testing
- `make test`
- `make bench`
- `build-bench/perf_compare_int256_bit`


------
https://chatgpt.com/codex/tasks/task_e_68b06d7c3fcc832986005acf84be9db1