### PR TITLE
test: cover stream output

### DIFF
--- a/tests/gint_test.cpp
+++ b/tests/gint_test.cpp
@@ -656,7 +656,7 @@ TEST(WideIntegerExtra, UnaryAndToString)
     EXPECT_EQ(d, (gint::integer<128, unsigned>(-1)));
 
     std::ostringstream oss;
-    oss << gint::to_string(b);
+    oss << b;
     EXPECT_EQ(oss.str(), "1");
 
     EXPECT_EQ(fmt::format("{}", b), "1");
@@ -942,6 +942,14 @@ TEST(WideIntegerStream, Output)
     std::ostringstream oss;
     oss << v;
     EXPECT_EQ(oss.str(), "42");
+}
+
+TEST(WideIntegerStream, OutputNegative)
+{
+    gint::integer<128, signed> v = -42;
+    std::ostringstream oss;
+    oss << v;
+    EXPECT_EQ(oss.str(), "-42");
 }
 
 TEST(WideIntegerMulLimbOverflow, AllOnes)


### PR DESCRIPTION
## Summary
- stream gint::integer directly into std::ostringstream
- add test for negative value output

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b1c8c584f08329b4b3ee9dbb26e5dd