### PR TITLE
Add tests for numeric_limits utility functions

### DIFF
--- a/tests/gint_test.cpp
+++ b/tests/gint_test.cpp
@@ -848,6 +848,22 @@ TEST(WideIntegerNumericLimits, Basic)
     expected <<= 127;
     expected = -expected;
     EXPECT_EQ(smin, expected);
+
+    EXPECT_EQ(std::numeric_limits<U>::lowest(), std::numeric_limits<U>::min());
+    EXPECT_EQ(std::numeric_limits<U>::epsilon(), U(0));
+    EXPECT_EQ(std::numeric_limits<U>::round_error(), U(0));
+    EXPECT_EQ(std::numeric_limits<U>::infinity(), U(0));
+    EXPECT_EQ(std::numeric_limits<U>::quiet_NaN(), U(0));
+    EXPECT_EQ(std::numeric_limits<U>::signaling_NaN(), U(0));
+    EXPECT_EQ(std::numeric_limits<U>::denorm_min(), U(0));
+
+    EXPECT_EQ(std::numeric_limits<S>::lowest(), std::numeric_limits<S>::min());
+    EXPECT_EQ(std::numeric_limits<S>::epsilon(), S(0));
+    EXPECT_EQ(std::numeric_limits<S>::round_error(), S(0));
+    EXPECT_EQ(std::numeric_limits<S>::infinity(), S(0));
+    EXPECT_EQ(std::numeric_limits<S>::quiet_NaN(), S(0));
+    EXPECT_EQ(std::numeric_limits<S>::signaling_NaN(), S(0));
+    EXPECT_EQ(std::numeric_limits<S>::denorm_min(), S(0));
 }
 
 TEST(WideIntegerBuiltin, FloatingTypes)


### PR DESCRIPTION
## Summary
- expand numeric_limits tests to cover lowest/epsilon/round_error/infinity/quiet_NaN/signaling_NaN/denorm_min

## Testing
- `cmake -S . -B build -DGINT_BUILD_TESTS=ON -DGINT_BUILD_BENCHMARKS=OFF`
- `cmake --build build --config Debug`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b1c8c5722083299af366a1bdac146a