### PR TITLE
refactor tests: split multiplication cases and unify suite names

### DIFF
--- a/tests/arithmetic_basic_test.cpp
+++ b/tests/arithmetic_basic_test.cpp
@@ -85,7 +85,7 @@ INSTANTIATE_TEST_SUITE_P(
         ArithCase{ArithOp::Mod, 200, 30, "20"}),
     arith_case_name);
 
-TEST(WideIntegerBasic, SignedArithmetic)
+TEST(WideIntegerArithmetic, SignedArithmetic)
 {
     gint::integer<128, signed> a = -5;
     gint::integer<128, signed> b = 2;
@@ -93,7 +93,7 @@ TEST(WideIntegerBasic, SignedArithmetic)
     EXPECT_EQ(gint::to_string(c), "-3");
 }
 
-TEST(WideInteger256, Arithmetic)
+TEST(WideIntegerArithmetic, UInt256)
 {
     using U = gint::integer<256, unsigned>;
     U a = (U(1) << 200) + (U(1) << 100) + 123;
@@ -103,7 +103,7 @@ TEST(WideInteger256, Arithmetic)
     EXPECT_TRUE(c > b);
 }
 
-TEST(WideInteger512, Arithmetic)
+TEST(WideIntegerArithmetic, UInt512)
 {
     using U = gint::integer<512, unsigned>;
     U a = (U(1) << 400) + (U(1) << 200) + 123456789;
@@ -113,7 +113,7 @@ TEST(WideInteger512, Arithmetic)
 }
 
 // From mul_limb_overflow_test.cpp
-TEST(WideIntegerMulLimbOverflow, AllOnes)
+TEST(WideIntegerArithmetic, MulLimbOverflowAllOnes)
 {
     using U256 = gint::integer<256, unsigned>;
     U256 a = 0;

--- a/tests/arithmetic_divmod_test.cpp
+++ b/tests/arithmetic_divmod_test.cpp
@@ -1,20 +1,21 @@
 #include <gint/gint.h>
 #include <gtest/gtest.h>
 
-TEST(WideIntegerOps, SmallMulDiv)
+TEST(WideIntegerDivision, SmallDivMod)
 {
     using UInt256 = gint::integer<256, unsigned>;
     UInt256 a = (UInt256(1) << 128) + 5;
-    UInt256 b = a * 3ULL;
+    UInt256 b = (a << 1) + a;
     EXPECT_EQ(b / 3ULL, a);
     EXPECT_EQ(b % 3ULL, UInt256(0));
 
     UInt256 c = UInt256(123456789);
-    EXPECT_EQ(c * 7ULL, UInt256(864197523));
-    EXPECT_EQ((c * 7ULL) / 7ULL, c);
+    UInt256 d = UInt256(864197523);
+    EXPECT_EQ(d / 7ULL, c);
+    EXPECT_EQ(d % 7ULL, UInt256(0));
 }
 
-TEST(WideIntegerOps, LargeLimbDivMod)
+TEST(WideIntegerDivision, LargeLimbDivMod)
 {
     using UInt256 = gint::integer<256, unsigned>;
     UInt256 u = UInt256(1);
@@ -34,7 +35,7 @@ TEST(WideIntegerOps, LargeLimbDivMod)
     EXPECT_EQ(s % div, Int256(0));
 }
 
-TEST(WideIntegerOps, SignedSmallDivMod)
+TEST(WideIntegerDivision, SignedSmallDivMod)
 {
     using Int256 = gint::integer<256, signed>;
     Int256 a = 123;
@@ -49,7 +50,7 @@ TEST(WideIntegerOps, SignedSmallDivMod)
     EXPECT_EQ(b % -5, Int256(-3));
 }
 
-TEST(WideIntegerOps, SignedInt128DivMod)
+TEST(WideIntegerDivision, SignedInt128DivMod)
 {
     using Int256 = gint::integer<256, signed>;
     Int256 pos = 123;
@@ -72,7 +73,7 @@ TEST(WideIntegerOps, SignedInt128DivMod)
     EXPECT_EQ(q * big_div + r, big);
 }
 
-TEST(WideIntegerOps, LongDivisionCorrection)
+TEST(WideIntegerDivision, LongDivisionCorrection)
 {
     using UInt256 = gint::integer<256, unsigned>;
     UInt256 dividend = (UInt256(1ULL << 63) << 192) | (UInt256(12345) << 128) | (UInt256(98764) << 64) | UInt256(42);
@@ -166,7 +167,7 @@ TEST(WideIntegerDivision, LargeShiftSubtract512)
     EXPECT_EQ(q * divisor + r, lhs);
 }
 
-TEST(WideIntegerDivModSmall, SingleLimbZero)
+TEST(WideIntegerDivision, SingleLimbZero)
 {
     using U128 = gint::integer<128, unsigned>;
     U128 one = 1;
@@ -176,7 +177,7 @@ TEST(WideIntegerDivModSmall, SingleLimbZero)
     EXPECT_EQ(zero, U128(0));
 }
 
-TEST(WideIntegerDivModSmall, SingleLimbBasic)
+TEST(WideIntegerDivision, SingleLimbBasic)
 {
     using U128 = gint::integer<128, unsigned>;
     U128 a = (U128(1) << 64) + 123;
@@ -186,7 +187,7 @@ TEST(WideIntegerDivModSmall, SingleLimbBasic)
     EXPECT_EQ(q * b + r, a);
 }
 
-TEST(WideIntegerDivModSmall, MultiLimbZero)
+TEST(WideIntegerDivision, MultiLimbZero)
 {
     using U256 = gint::integer<256, unsigned>;
     U256 a = 0;
@@ -237,7 +238,7 @@ TEST(WideIntegerDivision, LimbGreaterThanMaxSigned)
     EXPECT_EQ(q1 * rhs + r1, a);
 }
 
-TEST(WideIntegerU64DivMod, ZeroAndNonZero)
+TEST(WideIntegerDivision, U64ZeroAndNonZero)
 {
     using U64 = gint::integer<64, unsigned>;
     // Zero fast-path
@@ -254,7 +255,7 @@ TEST(WideIntegerU64DivMod, ZeroAndNonZero)
     EXPECT_EQ(a % 7u, U64(static_cast<uint64_t>(r)));
 }
 
-TEST(WideIntegerS64DivMod, SignedDivByLimb)
+TEST(WideIntegerDivision, S64DivByLimb)
 {
     using S64 = gint::integer<64, signed>;
     S64 a = -((S64(1) << 62) + S64(5));
@@ -311,7 +312,7 @@ TEST(WideIntegerDivision, QhatAdjustmentBreak)
     EXPECT_EQ(q * rhs + r, lhs);
 }
 
-TEST(WideInteger256, Division)
+TEST(WideIntegerDivision, UInt256Division)
 {
     using W = gint::integer<256, unsigned>;
     W a = (W{1} << 200) + 123456789ULL;

--- a/tests/arithmetic_mul_test.cpp
+++ b/tests/arithmetic_mul_test.cpp
@@ -1,0 +1,13 @@
+#include <gint/gint.h>
+#include <gtest/gtest.h>
+
+TEST(WideIntegerMultiplication, SmallMul)
+{
+    using UInt256 = gint::integer<256, unsigned>;
+    UInt256 a = (UInt256(1) << 128) + 5;
+    UInt256 expected_b = (UInt256(3) << 128) + UInt256(15);
+    EXPECT_EQ(a * 3ULL, expected_b);
+
+    UInt256 c = UInt256(123456789);
+    EXPECT_EQ(c * 7ULL, UInt256(864197523));
+}

--- a/tests/bitwise_test.cpp
+++ b/tests/bitwise_test.cpp
@@ -66,14 +66,14 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(BitCase{BitOp::And, 10, 12, "8"}, BitCase{BitOp::Or, 10, 12, "14"}, BitCase{BitOp::Xor, 10, 12, "6"}),
     bit_case_name);
 
-TEST(WideIntegerAdditional, BitwiseNot)
+TEST(WideIntegerBitwise, BitwiseNot)
 {
     gint::integer<128, unsigned> a = 0;
     auto b = ~a;
     EXPECT_EQ(gint::to_string(b), "340282366920938463463374607431768211455");
 }
 
-TEST(WideInteger256, BitwiseAndShift)
+TEST(WideIntegerBitwise, BitwiseAndShift256)
 {
     using U = gint::integer<256, unsigned>;
     U v = 1;
@@ -82,7 +82,7 @@ TEST(WideInteger256, BitwiseAndShift)
     EXPECT_EQ((s & v), U(0));
 }
 
-TEST(WideInteger512, BitwiseOps)
+TEST(WideIntegerBitwise, BitwiseOps512)
 {
     using U = gint::integer<512, unsigned>;
     U a = U(1) << 511;

--- a/tests/comparison_test.cpp
+++ b/tests/comparison_test.cpp
@@ -2,7 +2,7 @@
 #include <gint/gint.h>
 #include <gtest/gtest.h>
 
-TEST(WideIntegerAdditional, Comparison)
+TEST(WideIntegerComparison, UnsignedBasic)
 {
     gint::integer<128, unsigned> a = 5;
     gint::integer<128, unsigned> b = 10;
@@ -12,7 +12,7 @@ TEST(WideIntegerAdditional, Comparison)
     EXPECT_TRUE(b >= a);
 }
 
-TEST(WideIntegerAdditional, BuiltinComparison)
+TEST(WideIntegerComparison, BuiltinComparison)
 {
     gint::integer<128, unsigned> a = 5;
     int32_t iv = 10;
@@ -43,7 +43,7 @@ TEST(WideIntegerComparison, Floating)
     EXPECT_TRUE(0.0 >= a);
 }
 
-TEST(WideInteger256, Comparison)
+TEST(WideIntegerComparison, UInt256)
 {
     using U = gint::integer<256, unsigned>;
     U a = U(1) << 200;
@@ -54,7 +54,7 @@ TEST(WideInteger256, Comparison)
     EXPECT_TRUE(a >= a);
 }
 
-TEST(WideInteger512, Comparison)
+TEST(WideIntegerComparison, UInt512)
 {
     using U = gint::integer<512, unsigned>;
     U a = U(1) << 500;

--- a/tests/construction_test.cpp
+++ b/tests/construction_test.cpp
@@ -1,7 +1,7 @@
 #include <gint/gint.h>
 #include <gtest/gtest.h>
 
-TEST(WideIntegerConstexpr, Construction)
+TEST(WideIntegerConstruction, ConstexprConstruction)
 {
     constexpr gint::integer<128, unsigned> a = 42;
     static_assert(a == 42, "constexpr constructor failed");

--- a/tests/conversion_test.cpp
+++ b/tests/conversion_test.cpp
@@ -4,7 +4,7 @@
 #include <gint/gint.h>
 #include <gtest/gtest.h>
 
-TEST(WideIntegerOps, Int128NegativeConversion)
+TEST(WideIntegerConversion, Int128NegativeConversion)
 {
     using gint::Int256;
     __int128 small = -5;
@@ -178,7 +178,7 @@ TEST(WideIntegerConversion, ArithmeticWithBuiltin)
     EXPECT_EQ(gint::to_string(e), "2000");
 }
 
-TEST(WideIntegerInt128, UnsignedRoundtrip)
+TEST(WideIntegerConversion, UnsignedRoundtripInt128)
 {
     unsigned __int128 value = (static_cast<unsigned __int128>(1) << 80) + 42;
     gint::integer<256, unsigned> w = value;
@@ -186,7 +186,7 @@ TEST(WideIntegerInt128, UnsignedRoundtrip)
     EXPECT_EQ(back, value);
 }
 
-TEST(WideIntegerInt128, SignedRoundtrip)
+TEST(WideIntegerConversion, SignedRoundtripInt128)
 {
     __int128 value = -((static_cast<__int128>(1) << 90) + 77);
     gint::integer<256, signed> w = value;
@@ -194,7 +194,7 @@ TEST(WideIntegerInt128, SignedRoundtrip)
     EXPECT_EQ(back, value);
 }
 
-TEST(WideIntegerInt128, Arithmetic)
+TEST(WideIntegerConversion, Int128Arithmetic)
 {
     gint::integer<256, unsigned> w = 100;
     unsigned __int128 b = 20;
@@ -206,7 +206,7 @@ TEST(WideIntegerInt128, Arithmetic)
     EXPECT_EQ(gint::to_string(e), "2000");
 }
 
-TEST(WideIntegerInt128, SignedToUnsignedConversion)
+TEST(WideIntegerConversion, SignedToUnsignedConversion)
 {
     gint::integer<256, signed> w = 123;
     auto via_explicit = static_cast<unsigned __int128>(w);
@@ -217,7 +217,7 @@ TEST(WideIntegerInt128, SignedToUnsignedConversion)
     EXPECT_TRUE(neg_explicit == static_cast<unsigned __int128>(-1));
 }
 
-TEST(WideIntegerInt128, SignedConversion)
+TEST(WideIntegerConversion, SignedConversionInt128)
 {
     gint::integer<256, signed> w = 123;
     auto via_explicit = static_cast<__int128>(w);
@@ -288,7 +288,7 @@ static void test_float_ops()
     EXPECT_TRUE(a != b);
 }
 
-TEST(WideIntegerBuiltin, IntegralTypes)
+TEST(WideIntegerConversion, IntegralTypes)
 {
     test_integral_ops<int8_t>();
     test_integral_ops<uint8_t>();
@@ -302,7 +302,7 @@ TEST(WideIntegerBuiltin, IntegralTypes)
     test_integral_ops<unsigned __int128>();
 }
 
-TEST(WideIntegerBuiltin, FloatingTypes)
+TEST(WideIntegerConversion, FloatingTypes)
 {
     test_float_ops<float>();
     test_float_ops<double>();
@@ -316,7 +316,7 @@ TEST(WideIntegerConversion, LongDoubleZero)
     EXPECT_EQ(from_zero, (gint::integer<128, unsigned>(0)));
 }
 
-TEST(WideIntegerExtra, FloatConversion)
+TEST(WideIntegerConversion, ExtraFloatConversion)
 {
     gint::integer<128, unsigned> v = 123;
     double d = static_cast<double>(v);

--- a/tests/shift_test.cpp
+++ b/tests/shift_test.cpp
@@ -1,7 +1,7 @@
 #include <gint/gint.h>
 #include <gtest/gtest.h>
 
-TEST(WideIntegerBasic, Shift)
+TEST(WideIntegerShift, Basic)
 {
     gint::integer<128, unsigned> a = 1;
     auto left = a << 100;


### PR DESCRIPTION
## Summary
- refactor div/mod tests to remove embedded multiplication checks
- add dedicated multiplication test file
- standardize test suite names across files

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b29247ff308329b3949c92316ba521