### PR TITLE
Add macro cleanup to gint.h

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1633,3 +1633,11 @@ struct formatter<gint::integer<Bits, Signed>>
 };
 } // namespace fmt
 #endif
+
+//=== Macro cleanup =============================================================
+
+#undef GINT_UNLIKELY
+#undef GINT_ZERO_CHECK
+#undef GINT_DIVZERO_CHECK
+#undef GINT_MODZERO_CHECK
+#undef GINT_CONSTEXPR14


### PR DESCRIPTION
## Summary
- add macro cleanup section for exported macros in `gint.h`

## Testing
- `cmake -S . -B build -DGINT_BUILD_TESTS=ON -DGINT_BUILD_BENCHMARKS=OFF`
- `cmake --build build --config Debug`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b2b47ec3688329a77c9694627e2061