### PR TITLE
refactor: 提升测试覆盖率（乘法/除法/浮点比较/字符串/比较）

### DIFF
--- a/tests/arithmetic_divmod_test.cpp
+++ b/tests/arithmetic_divmod_test.cpp
@@ -370,3 +370,15 @@ TEST(WideIntegerDivision, DivLargeBreak)
     U192 q = U192::div_large(lhs, divisor, 2);
     EXPECT_EQ(static_cast<uint64_t>(q), 1ULL);
 }
+
+// Exercise div_mod_small 64-bit divisor generic path for limbs != 4 (here: 192-bit)
+TEST(WideIntegerDivision, DivModSmall64GenericU192)
+{
+    using U192 = gint::integer<192, unsigned>;
+    U192 lhs = (U192(1) << 190) + (U192(1) << 128) + U192(123456789ULL);
+    uint64_t div = (1ULL << 63) + 123ULL; // > 32-bit -> 64-bit reciprocal branch
+
+    U192 q = lhs / div; // goes through integer(rhs) -> small divisor -> div_mod_small generic
+    U192 r = lhs % div;
+    EXPECT_EQ(q * U192(div) + r, lhs);
+}

--- a/tests/arithmetic_mul_test.cpp
+++ b/tests/arithmetic_mul_test.cpp
@@ -11,3 +11,110 @@ TEST(WideIntegerMultiplication, SmallMul)
     UInt256 c = UInt256(123456789);
     EXPECT_EQ(c * 7ULL, UInt256(864197523));
 }
+
+// 128-bit wide×wide multiplication specialized path (mul_limbs<2>)
+TEST(WideIntegerMultiplication, UInt128_WideTimesWide_Specialized)
+{
+    using U128 = gint::integer<128, unsigned>;
+    unsigned __int128 ai = (static_cast<unsigned __int128>(1) << 100) + 0x1234;
+    unsigned __int128 bi = (static_cast<unsigned __int128>(1) << 80) + 0x5678;
+    U128 a = ai;
+    U128 b = bi;
+    U128 p = a * b; // keeps low 128 bits
+    unsigned __int128 expected = ai * bi; // implicit mod 2^128
+    EXPECT_EQ(p, U128(expected));
+}
+
+// 256-bit wide×wide multiplication (mul_limbs<4> Comba path)
+TEST(WideIntegerMultiplication, UInt256_WideTimesWide_Comba)
+{
+    using U256 = gint::integer<256, unsigned>;
+    U256 a = 0;
+    a += U256(0x1122334455667788ULL);
+    a += U256(0x99AABBCCDDEEFF00ULL) << 64;
+    a += U256(0x0123456789ABCDEFULL) << 128;
+    a += U256(0x0001112223334444ULL) << 192;
+
+    U256 three = U256(3);
+    U256 prod = a * three;
+    U256 sum = a + a + a;
+    EXPECT_EQ(prod, sum);
+}
+
+// 192-bit wide×wide multiplication (generic mul_limbs path)
+TEST(WideIntegerMultiplication, UInt192_WideTimesWide_Generic)
+{
+    using U192 = gint::integer<192, unsigned>;
+    U192 a = 0;
+    a += U192(0xCAFEBABE8BADF00DULL);
+    a += U192(0x0011223344556677ULL) << 64;
+    a += U192(0x0102030405060708ULL) << 128;
+
+    U192 five = U192(5);
+    U192 prod = a * five;
+    U192 sum = a + a + a + a + a;
+    EXPECT_EQ(prod, sum);
+}
+
+// 192-bit multiply-by-1 to exercise generic mul path without carry
+TEST(WideIntegerMultiplication, UInt192_TimesOne_NoCarry)
+{
+    using U192 = gint::integer<192, unsigned>;
+    U192 a = 0;
+    a += U192(0x1111222233334444ULL);
+    a += U192(0x5555666677778888ULL) << 64;
+    a += U192(0x9999AAAABBBBCCCCULL) << 128;
+    U192 one = U192(1);
+    U192 prod = a * one;
+    EXPECT_EQ(prod, a);
+}
+
+// 192-bit multiply-by-2 to force carries through generic mul
+TEST(WideIntegerMultiplication, UInt192_TimesTwo_WithCarry)
+{
+    using U192 = gint::integer<192, unsigned>;
+    U192 a = ~U192(0); // all ones
+    U192 prod = a * U192(2);
+    U192 expected = a;
+    expected <<= 1; // fixed-width semantics
+    EXPECT_EQ(prod, expected);
+}
+
+// 320-bit wide×wide multiplication (generic mul_limbs path)
+TEST(WideIntegerMultiplication, UInt320_WideTimesWide_Generic)
+{
+    using U320 = gint::integer<320, unsigned>;
+    U320 a = 0;
+    a += U320(0xDEADBEEFDEADBEEFULL);
+    a += U320(0xC001D00DC001D00DULL) << 64;
+    a += U320(0x0123456789ABCDEFULL) << 128;
+    a += U320(0x0) << 192;
+    a += U320(0x2222222211111111ULL) << 256;
+
+    U320 two = U320(2);
+    U320 prod = a * two;
+    U320 sum = a + a;
+    EXPECT_EQ(prod, sum);
+}
+
+// Multiplication by power-of-two equals left shift (wide×wide trigger)
+TEST(WideIntegerMultiplication, UInt256_MulByPow2EqualsShift)
+{
+    using U256 = gint::integer<256, unsigned>;
+    U256 a = (U256(0xABCDEF0123456789ULL) << 128) + U256(0x0123456789ABCDEFULL);
+    U256 pow2 = U256(1) << 13; // ensure wide×wide code path
+    U256 prod = a * pow2;
+    U256 shifted = a;
+    shifted <<= 13;
+    EXPECT_EQ(prod, shifted);
+}
+
+// Addition with cascading carries across multiple limbs
+TEST(WideIntegerMultiplication, UInt256_AdditionCarryChain)
+{
+    using U256 = gint::integer<256, unsigned>;
+    U256 a = U256(0xffffffffffffffffULL) + (U256(0xffffffffffffffffULL) << 64);
+    U256 b = 1;
+    U256 sum = a + b;
+    EXPECT_EQ(sum - b, a);
+}

--- a/tests/comparison_test.cpp
+++ b/tests/comparison_test.cpp
@@ -64,3 +64,21 @@ TEST(WideIntegerComparison, UInt512)
     EXPECT_TRUE(a != b);
     EXPECT_TRUE(a >= a);
 }
+
+TEST(WideIntegerComparison, LimbsEqualShortCircuitPaths)
+{
+    using U256 = gint::integer<256, unsigned>;
+    U256 base = (U256(1) << 200) + (U256(1) << 100) + U256(5);
+    U256 a = base;
+    U256 b = base;
+    // All equal path
+    EXPECT_TRUE(a == b);
+
+    // Highest limb differs (short-circuit at top level)
+    U256 c = b + (U256(1) << 192);
+    EXPECT_FALSE(b == c);
+
+    // Highest limb equal, next limb differs
+    U256 d = b + (U256(1) << 128);
+    EXPECT_FALSE(b == d);
+}

--- a/tests/conversion_test.cpp
+++ b/tests/conversion_test.cpp
@@ -333,3 +333,12 @@ TEST(WideIntegerConversion, ExtraFloatConversion)
     gint::integer<128, signed> s = d2;
     EXPECT_EQ(s, -789);
 }
+
+TEST(WideIntegerConversion, BoolConversion)
+{
+    using U128 = gint::integer<128, unsigned>;
+    U128 z = 0;
+    U128 o = 1;
+    EXPECT_FALSE(static_cast<bool>(z));
+    EXPECT_TRUE(static_cast<bool>(o));
+}

--- a/tests/float_interop_edge_test.cpp
+++ b/tests/float_interop_edge_test.cpp
@@ -177,3 +177,41 @@ TEST(FloatInteropEdges, ArithmeticWithInfAndNaN)
     EXPECT_THROW((void)(ninf % d), std::domain_error);
     EXPECT_THROW((void)(nan % d), std::domain_error);
 }
+
+TEST(FloatInteropEdges, CompareWithFloat_ShiftPositive_ExactAndExtra)
+{
+    using U256 = gint::integer<256, unsigned>;
+    // shift > 0 and exact representable as double
+    U256 a = U256(1) << 200;
+    double d = std::ldexp(1.0, 200);
+    EXPECT_TRUE(a == d);
+    EXPECT_FALSE(a != d);
+    EXPECT_TRUE(a <= d);
+    EXPECT_TRUE(a >= d);
+
+    // shift > 0 and lhs has extra low bits -> lhs > rhs
+    U256 a2 = a + U256(1);
+    EXPECT_TRUE(a2 > d);
+    EXPECT_FALSE(a2 == d);
+}
+
+TEST(FloatInteropEdges, CompareWithFloat_ShiftNonPositive_FractionalTail)
+{
+    using U256 = gint::integer<256, unsigned>;
+    U256 a = 42;
+    double d = 42.25; // fractional tail beyond integer
+    EXPECT_TRUE(a < d);
+    EXPECT_TRUE(d > a);
+    EXPECT_FALSE(a == d);
+}
+
+TEST(FloatInteropEdges, CompareWithFloat_FloatPrecision)
+{
+    using U256 = gint::integer<256, unsigned>;
+    // float p=24, shift > 0
+    U256 a = U256(1) << 30;
+    U256 a2 = a + U256(1);
+    float f = std::ldexp(1.0f, 30);
+    EXPECT_TRUE(a == f);
+    EXPECT_TRUE(a2 > f);
+}

--- a/tests/stream_test.cpp
+++ b/tests/stream_test.cpp
@@ -25,3 +25,16 @@ TEST(WideIntegerStream, OutputZero)
     oss << v;
     EXPECT_EQ(oss.str(), "0");
 }
+
+TEST(WideIntegerStream, ToStringChunksWithZeros)
+{
+    using U = gint::integer<256, unsigned>;
+    const U base = U(1000000000ULL); // 1e9
+    U v = U(123);
+    v *= base; // * 1e9
+    v *= base; // * 1e18
+    v *= base; // * 1e27
+    v += U(45);
+    // Expect three zero chunks (9 digits each) between 123 and 045
+    EXPECT_EQ(gint::to_string(v), std::string("123000000000000000000000000045"));
+}


### PR DESCRIPTION
标题：refactor: 提升测试覆盖率（乘法/除法/浮点比较/字符串/比较）

动机
- 目的：增强核心算子与边界路径的测试覆盖，提升对专用与泛型实现、进位/借位、以及浮点对齐等分支的验证强度。
- 非功能性：不改变对外行为，仅补充与整合单元测试。

范围
- 涉及位置：tests/arithmetic_mul_test.cpp、tests/arithmetic_divmod_test.cpp、tests/float_interop_edge_test.cpp、tests/stream_test.cpp、tests/comparison_test.cpp
- 构建影响：无新增依赖与目标，沿用既有测试二进制；覆盖构建通过（ENABLE_COVERAGE=ON）。

行为不变性说明
- 与 docs/TECH_SPEC.md 的一致性：保持严格位宽、补码、移位、比较、模算术等既有语义不变。
- 互操作：原生整数/__int128/浮点的构造、算术、比较与转换行为不变。

验证
- 单元测试：新增用例覆盖
  - 乘法：128 位专用 mul_limbs<2>；192/320 位泛型（含无进位/有进位）；乘以 2 的幂等价左移；跨 limb 进位加法
  - 除法：U192 + 64 位大除数命中非 4‑limb 的 div_mod_small(64) 路径
  - 浮点比较：compare_with_float_abs 的 shift>0（精确一致/有额外低位）与 shift<=0（小数尾）分支（含 float/double）
  - 字符串：1e9 分块中间含零块的零填充
  - 比较：limbs_equal 最高 limb 短路/递归路径
- 本地结果：ctest 通过（Release 与 Debug+coverage）
- 覆盖率（仅统计 include/）：
  - Lines: 91.2% (925/1014)
  - Functions: 92.8% (803/865)
  - Branches: 48.1% (890/1850)
  - HTML 报告：build-cov/coverage/index.html

可选：性能
- 不适用（仅测试补充）。

回归与兼容性评估
- API/ABI：无变更。
- 约束保持：
  - C++11 兼容与 Header‑only。
  - 严格位宽与原生类型互操作语义维持不变。

（补充）覆盖率未接近 100% 的原因
- Header‑only 模板：大量行仅在特定 Bits/有无符号或 SFINAE 条件下实例化；单一构建难以覆盖所有特化与路径。
- 宏/标准互斥：如 GINT_ENABLE_DIVZERO_CHECKS、GINT_ENABLE_FMT、C++11/14/17 路径互斥；需多配置矩阵合并报告才可能进一步提升。
- 算法分支组合复杂：小除数（32/64）、Knuth 大数除法 q̂ 修正、移位 limb/bit 组合、浮点对齐分支等；为覆盖全部行需大量“为覆盖而覆盖”的极端用例，收益有限且脆弱。
- 纯编译期路径：numeric_limits 与部分 constexpr/特征检测为编译期验证，不产生运行时代码命中。

清单（提交前请逐项勾选）
- [x] 分支名为英文（PR 指南要求）
- [x] 已运行 clang-format（使用仓库根目录 `.clang-format`）
- [x] tests 已覆盖新增路径，ctest 通过
- [x] 未更改公共 API 或行为
- [x] 未引入不必要依赖，构建脚本保持一致
- [x] 保持 C++11 兼容与 Header-only 特性
- [x] 保持严格位宽与原生类型互操作语义