### PR TITLE
fix: unsigned negative divisor handling

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1416,6 +1416,7 @@ public:
     friend integer operator%(integer lhs, T rhs)
     {
         GINT_MODZERO_CHECK(rhs == 0);
+        // For unsigned integers, mimic native casts: reinterpret negative divisors as their two's complement magnitude.
         if (std::is_same<Signed, unsigned>::value && detail::is_signed<T>::value && rhs < 0)
             return lhs % integer(rhs);
         if (sizeof(T) <= sizeof(limb_type)

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1416,6 +1416,8 @@ public:
     friend integer operator%(integer lhs, T rhs)
     {
         GINT_MODZERO_CHECK(rhs == 0);
+        if (std::is_same<Signed, unsigned>::value && detail::is_signed<T>::value && rhs < 0)
+            return lhs % integer(rhs);
         if (sizeof(T) <= sizeof(limb_type)
             && (!detail::is_unsigned<T>::value || rhs <= static_cast<T>(std::numeric_limits<signed_limb_type>::max())))
         {

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1364,6 +1364,7 @@ public:
     friend integer operator%(integer lhs, signed_limb_type rhs)
     {
         GINT_MODZERO_CHECK(rhs == 0);
+        // For unsigned integers, mimic native casts: reinterpret negative divisors as their two's complement magnitude.
         if (std::is_same<Signed, unsigned>::value && rhs < 0)
             return lhs % integer(rhs);
         integer q;

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1334,6 +1334,9 @@ public:
     friend integer operator/(integer lhs, signed_limb_type rhs)
     {
         GINT_DIVZERO_CHECK(rhs == 0);
+        // For unsigned integers, mimic native casts: reinterpret negative divisors as their two's complement magnitude.
+        if (std::is_same<Signed, unsigned>::value && rhs < 0)
+            return lhs / integer(rhs);
         integer q;
         lhs.div_mod_small(rhs, q);
         return q;
@@ -1361,6 +1364,8 @@ public:
     friend integer operator%(integer lhs, signed_limb_type rhs)
     {
         GINT_MODZERO_CHECK(rhs == 0);
+        if (std::is_same<Signed, unsigned>::value && rhs < 0)
+            return lhs % integer(rhs);
         integer q;
         signed_limb_type r = lhs.div_mod_small(rhs, q);
         return integer(r);

--- a/tests/arithmetic_divmod_test.cpp
+++ b/tests/arithmetic_divmod_test.cpp
@@ -394,6 +394,24 @@ TEST(WideIntegerDivision, UnsignedNegativeDivisorReinterpreted)
     EXPECT_EQ(small % neg_two, small);
 }
 
+TEST(WideIntegerDivision, UnsignedNegativeDivisorSmallBuiltin)
+{
+    using U256 = gint::integer<256, unsigned>;
+    U256 small = 5;
+    int8_t neg_byte = -1;
+    int16_t neg_word = -7;
+
+    EXPECT_EQ(small / neg_byte, U256(0));
+    EXPECT_EQ(small % neg_byte, small);
+
+    EXPECT_EQ(small / neg_word, U256(0));
+    EXPECT_EQ(small % neg_word, small);
+
+    U256 all_ones = ~U256(0);
+    EXPECT_EQ(all_ones / neg_byte, U256(1));
+    EXPECT_EQ(all_ones % neg_byte, U256(0));
+}
+
 TEST(WideIntegerDivision, LargeShiftSubtract512)
 {
     using U512 = gint::integer<512, unsigned>;

--- a/tests/arithmetic_divmod_test.cpp
+++ b/tests/arithmetic_divmod_test.cpp
@@ -375,6 +375,25 @@ TEST(WideIntegerDivision, TwoLimbBorrowLowPartCritical)
     EXPECT_EQ(r_fast, r_generic);
 }
 
+TEST(WideIntegerDivision, UnsignedNegativeDivisorReinterpreted)
+{
+    using U256 = gint::integer<256, unsigned>;
+    U256 small = 5;
+    int64_t neg_one = -1;
+
+    // Negative divisors should be reinterpreted as unsigned magnitudes, not routed through signed sign-flip logic.
+    EXPECT_EQ(small / neg_one, U256(0));
+    EXPECT_EQ(small % neg_one, small);
+
+    U256 all_ones = ~U256(0);
+    EXPECT_EQ(all_ones / neg_one, U256(1));
+    EXPECT_EQ(all_ones % neg_one, U256(0));
+
+    int64_t neg_two = -2;
+    EXPECT_EQ(small / neg_two, U256(0));
+    EXPECT_EQ(small % neg_two, small);
+}
+
 TEST(WideIntegerDivision, LargeShiftSubtract512)
 {
     using U512 = gint::integer<512, unsigned>;


### PR DESCRIPTION
问题描述
- 现象：无符号整数与负数内建整型做除/模时会走带符号路径，结果与原生转换不一致（例如 5u / -1 返回 ~4）。
- 期望：负除数/模数应按两补码重解释为大正数，与原生无符号算术一致。
- 影响面：无符号宽整数与内建有符号整型的除/模互操作，适用于所有位宽。

根因分析
- 代码位置：include/gint/gint.h 中 operator/(integer, signed_limb_type) 与 operator%(integer, signed_limb_type) 路径。
- 触发条件：Signed == unsigned 且 rhs < 0 时被派发到 div_mod_small 的符号翻转逻辑。

修复方案
- 方案说明：无符号分支检测负 rhs，先重解释为宽整数再走无符号路径，保持与原生转换一致；将新增注释改为英文。
- 兼容性：行为更正，无公共 API 变更。

测试与验证
- 新增/更新测试：tests/arithmetic_divmod_test.cpp 覆盖无符号与负除/模数。
- 本地验证：ctest（build）通过 150/150。
- 回归风险：关键路径；运行 `BENCH_BUILD_DIR=runs/local/build-bench make bench BENCH_ARGS="--benchmark_min_time=0.05s"`，Div/SmallDivisor32≈10.2ns，Div/SmallDivisor64≈12.8ns，未见回退。

清单（提交前请逐项勾选）
- [x] 分支名为英文（PR 指南要求）
- [x] 已运行 clang-format（使用仓库根目录 `.clang-format`）
- [x] 新增/更新了回归测试，`make test` 通过
- [x] 修复遵循既有语义：严格位宽、补码、移位、比较与模算术
- [x] 不改变公共 API（除非是对既有行为错误的更正）
- [x] 若触及性能关键路径，已确认无显著回退或已给出数据
- [x] 如变更文档/注释，已同步更新 `docs/` 或注释
