### PR TITLE
fix: guard zero divisor when checks off

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1283,6 +1283,8 @@ public:
         while (divisor_limbs > 0 && divisor.data_[divisor_limbs - 1] == 0)
             --divisor_limbs;
         GINT_DIVZERO_CHECK(divisor_limbs == 0);
+        if (GINT_UNLIKELY(divisor_limbs == 0))
+            return integer();
         bool small_divisor = divisor_limbs == 1;
         if (small_divisor)
         {
@@ -2096,6 +2098,8 @@ private:
         while (divisor_limbs > 0 && divisor_mag.data_[divisor_limbs - 1] == 0)
             --divisor_limbs;
         GINT_DIVZERO_CHECK(divisor_limbs == 0);
+        if (GINT_UNLIKELY(divisor_limbs == 0))
+            return integer();
         if (divisor_limbs == 1)
         {
             lhs_mag.div_mod_small(divisor_mag.data_[0], quotient_mag);

--- a/tests/arithmetic_basic_test.cpp
+++ b/tests/arithmetic_basic_test.cpp
@@ -169,3 +169,12 @@ TEST(WideIntegerArithmetic, SubBorrowChain256)
     expected += U256(0xffffffffffffffffULL) << 128;
     EXPECT_EQ(diff, expected);
 }
+
+TEST(WideIntegerArithmetic, DivZeroWithoutChecks)
+{
+    using U384 = gint::integer<384, unsigned>;
+    U384 value = (U384(1) << 300) + 123;
+    U384 zero = 0;
+    EXPECT_EQ(value / zero, U384(0));
+    EXPECT_EQ(value % zero, value);
+}

--- a/tests/float_interop_edge_test.cpp
+++ b/tests/float_interop_edge_test.cpp
@@ -140,6 +140,20 @@ TEST(FloatInteropEdges, NegativeNegativeOrdering)
     EXPECT_FALSE(m3 != f3);
 }
 
+TEST(FloatInteropEdges, CompareWithDouble_MinSigned)
+{
+    using S128 = gint::integer<128, signed>;
+    const S128 min = std::numeric_limits<S128>::min();
+    const double d = -std::ldexp(1.0, 127);
+    EXPECT_TRUE(min == d);
+    EXPECT_TRUE(d == min);
+    EXPECT_FALSE(min != d);
+    EXPECT_TRUE(min <= d);
+    EXPECT_TRUE(min >= d);
+    EXPECT_FALSE(min < d);
+    EXPECT_FALSE(min > d);
+}
+
 TEST(FloatInteropEdges, ArithmeticWithInfAndNaN)
 {
     using U256 = gint::integer<256, unsigned>;


### PR DESCRIPTION
标题：fix: guard zero divisor when checks off

问题描述
- 现象：关闭 `GINT_ENABLE_DIVZERO_CHECKS` 时，`integer / 0` 可能进入 `div_large` 并访问 `divisor.data_[div_limbs - 1]` 越界，返回值不确定；`%` 依赖 `/` 结果。
- 期望：关闭检查时也避免 OOB/UB；本次定义 `x / 0` 返回 0，`x % 0` 返回 `x`。
- 影响面：所有位宽/有无符号，在未启用除零检查时。

根因分析
- 代码位置：`include/gint/gint.h` 的 `operator/` 与 `div_unsigned_path`。
- 触发条件：除数为 0 且未启用 `GINT_ENABLE_DIVZERO_CHECKS`。

修复方案
- 在 `divisor_limbs == 0` 时直接返回零结果，避免进入 `div_large` 访问越界；在无符号最小值路径同样处理。
- 行为变更仅限“关闭检查且除数为 0”的未定义场景，属于 bug 修复。

测试与验证
- 新增/更新测试：
  - `tests/arithmetic_basic_test.cpp` `DivZeroWithoutChecks`（U384）。
  - `tests/float_interop_edge_test.cpp` `CompareWithDouble_MinSigned`（最小值场景未复现问题）。
- 本地验证：`make TEST_BUILD_DIR=runs/local/build-test test`
- 性能回归（local）：
  - 过滤器：`^Div/`
  - `BENCH_ARGS`: `--benchmark_filter=^Div/ --benchmark_min_time=1s --benchmark_out=... --benchmark_out_format=json --benchmark_report_aggregates_only=true`
  - `CMAKE_BUILD_TYPE`: Release
  - 编译器：AppleClang 17.0.0.17000603
  - 环境：Darwin 25.2.0 (arm64), CPU Apple M4 Pro, RAM 48 GiB
  - 基线提交：a6a9bbeda9c71edd05a0f7e14819dfed6d594fd7
  - 结果提交：ba52984642f650728301d94589ab095e21a9d915
  - 结果文件：
    - `runs/local/div_baseline_rerun.json`
    - `runs/local/div_result_rerun.json`
  - 结论：Div 四个用例均出现一致性回退，幅度约 3%–11%（Pow2Divisor ~11.2%、SmallDivisor32 ~6.9%、SmallDivisor64 ~2.9%、SimilarMagnitude ~4.5%）。

清单（提交前请逐项勾选）
- [x] 分支名为英文（PR 指南要求）
- [x] 已运行 clang-format（使用仓库根目录 `.clang-format`）
- [x] 新增/更新了回归测试，`make test` 通过
- [x] 修复遵循既有语义：严格位宽、补码、移位、比较与模算术
- [x] 不改变公共 API（除非是对既有行为错误的更正）
- [x] 若触及性能关键路径，已确认无显著回退或已给出数据
- [ ] 如变更文档/注释，已同步更新 `docs/` 或注释
