### PR TITLE
fix: stabilize divzero checks and test-only access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(GINT_BUILD_TESTS)
         target_link_options(gint_tests PRIVATE ${GINT_TEST_LINK_OPTIONS})
     endif()
     # fmt support is required by some tests; enable globally for the test target
-    target_compile_definitions(gint_tests PRIVATE GINT_ENABLE_FMT)
+    target_compile_definitions(gint_tests PRIVATE GINT_ENABLE_FMT GINT_TEST_ACCESS)
     target_link_libraries(gint_tests PRIVATE GTest::gtest_main fmt::fmt)
 
     # Increase discovery timeout to avoid flaky timeouts when listing tests
@@ -84,7 +84,7 @@ if(GINT_BUILD_TESTS)
             if(GINT_TEST_LINK_OPTIONS)
                 target_link_options(gint_tests_cxx17 PRIVATE ${GINT_TEST_LINK_OPTIONS})
             endif()
-            target_compile_definitions(gint_tests_cxx17 PRIVATE GINT_ENABLE_FMT)
+            target_compile_definitions(gint_tests_cxx17 PRIVATE GINT_ENABLE_FMT GINT_TEST_ACCESS)
             target_link_libraries(gint_tests_cxx17 PRIVATE GTest::gtest_main fmt::fmt)
             gtest_discover_tests(gint_tests_cxx17 NO_PRETTY_VALUES DISCOVERY_TIMEOUT 60)
         endif()

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -26,16 +26,12 @@
 #    define GINT_FORCE_INLINE inline
 #endif
 
-#if defined(GINT_ENABLE_DIVZERO_CHECKS)
-#    define GINT_ZERO_CHECK(cond, msg) \
-        do \
-        { \
-            if (GINT_UNLIKELY(cond)) \
-                throw std::domain_error(msg); \
-        } while (false)
-#else
-#    define GINT_ZERO_CHECK(cond, msg) ((void)0)
-#endif
+#define GINT_ZERO_CHECK(cond, msg) \
+    do \
+    { \
+        if (GINT_UNLIKELY(cond) && ::gint::detail::divzero_checks_enabled()) \
+            throw std::domain_error(msg); \
+    } while (false)
 #define GINT_DIVZERO_CHECK(cond) GINT_ZERO_CHECK(cond, "division by zero")
 #define GINT_MODZERO_CHECK(cond) GINT_ZERO_CHECK(cond, "modulo by zero")
 
@@ -101,6 +97,34 @@ using UInt256 = integer<256, unsigned>;
 //=== Internal helper utilities ==============================================
 namespace detail
 {
+GINT_FORCE_INLINE bool & divzero_checks_flag() noexcept
+{
+    static bool enabled = false;
+    return enabled;
+}
+
+GINT_FORCE_INLINE bool divzero_checks_enabled() noexcept
+{
+    return divzero_checks_flag();
+}
+
+#if defined(GINT_ENABLE_DIVZERO_CHECKS)
+struct divzero_checks_registrar
+{
+    divzero_checks_registrar() noexcept { divzero_checks_flag() = true; }
+};
+
+namespace
+{
+static const divzero_checks_registrar k_divzero_checks_registrar;
+}
+#endif
+
+#ifdef GINT_TEST_ACCESS
+template <size_t Bits, typename Signed>
+struct integer_test_access;
+#endif
+
 template <size_t Bits>
 struct storage_count
 {
@@ -703,9 +727,11 @@ template <size_t Bits, typename Signed>
 class integer
 {
 public:
+    static constexpr size_t bits = Bits;
     static constexpr size_t limbs = detail::storage_count<Bits>::value;
     using limb_type = uint64_t;
     using signed_limb_type = int64_t;
+    using signed_tag = Signed;
     // Constrain Signed to be exactly 'signed' or 'unsigned' tag types.
     static_assert(std::is_same<Signed, signed>::value || std::is_same<Signed, unsigned>::value, "Signed must be 'signed' or 'unsigned'.");
     template <size_t>
@@ -713,6 +739,9 @@ public:
     template <size_t, typename>
     friend class integer;
     friend class std::numeric_limits<integer<Bits, Signed>>;
+#ifdef GINT_TEST_ACCESS
+    friend struct detail::integer_test_access<Bits, Signed>;
+#endif
 
     // Constructors
     constexpr integer() noexcept = default;
@@ -1772,13 +1801,21 @@ private:
     template <typename T, typename std::enable_if<detail::is_integral<T>::value, int>::type = 0>
     void assign(T v) noexcept
     {
-        using wide = typename std::conditional<detail::is_signed<T>::value, __int128, unsigned __int128>::type;
-        wide val = static_cast<wide>(v);
-        for (size_t i = 0; i < limbs; ++i)
+        typedef __int128 wide_signed;
+        typedef unsigned __int128 wide_unsigned;
+        const bool sign_fill = detail::is_signed<T>::value && v < 0;
+        const limb_type fill = sign_fill ? ~limb_type(0) : limb_type(0);
+        wide_unsigned val = sign_fill ? static_cast<wide_unsigned>(static_cast<wide_signed>(v)) : static_cast<wide_unsigned>(v);
+
+        if (limbs > 0)
         {
-            data_[i] = static_cast<limb_type>(static_cast<unsigned __int128>(val));
+            data_[0] = static_cast<limb_type>(val);
             val >>= 64;
         }
+        if (limbs > 1)
+            data_[1] = static_cast<limb_type>(val);
+        for (size_t i = 2; i < limbs; ++i)
+            data_[i] = fill;
     }
 
     template <typename T>
@@ -2627,6 +2664,45 @@ private:
 
     alignas(16) limb_type data_[limbs] = {};
 };
+
+#ifdef GINT_TEST_ACCESS
+namespace detail
+{
+template <size_t Bits, typename Signed>
+struct integer_test_access
+{
+    using Int = integer<Bits, Signed>;
+    using limb_type = typename Int::limb_type;
+
+    static limb_type & limb(Int & value, size_t index) noexcept { return value.data_[index]; }
+
+    static const limb_type & limb(const Int & value, size_t index) noexcept { return value.data_[index]; }
+
+    static int highest_bit(const Int & value) noexcept { return value.highest_bit(); }
+
+    static bool is_min_value(const Int & value) noexcept { return Int::is_min_value(value); }
+
+    static Int div_unsigned_path(const Int & lhs, const Int & rhs, bool lhs_neg, bool rhs_neg, bool lhs_is_min, bool rhs_is_min)
+    {
+        return Int::div_unsigned_path(lhs, rhs, lhs_neg, rhs_neg, lhs_is_min, rhs_is_min);
+    }
+
+    static Int div_128(const Int & lhs, const Int & rhs) noexcept { return Int::div_128(lhs, rhs); }
+
+    static Int div_large(Int lhs, const Int & rhs, size_t div_limbs) noexcept { return Int::div_large(lhs, rhs, div_limbs); }
+
+    static Int div_large_2(Int lhs, const Int & rhs) noexcept { return Int::div_large_2(lhs, rhs); }
+
+    static Int div_large_3(Int lhs, const Int & rhs) noexcept { return Int::div_large_3(lhs, rhs); }
+
+    template <typename T>
+    static int compare_with_float_abs(const Int & lhs_abs, T rhs_abs) noexcept
+    {
+        return Int::template compare_with_float_abs<T>(lhs_abs, rhs_abs);
+    }
+};
+} // namespace detail
+#endif
 
 } // namespace gint
 

--- a/tests/arithmetic_divmod_test.cpp
+++ b/tests/arithmetic_divmod_test.cpp
@@ -1,8 +1,9 @@
 #define GINT_ENABLE_DIVZERO_CHECKS
-#define private public
 #include <gint/gint.h>
-#undef private
 #include <gtest/gtest.h>
+
+template <typename Int>
+using TestAccess = gint::detail::integer_test_access<Int::bits, typename Int::signed_tag>;
 
 TEST(WideIntegerDivision, SmallDivMod)
 {
@@ -311,11 +312,11 @@ TEST(WideIntegerDivision, TwoLimbFastPathMatchesGeneric)
     for (const auto & lhs : dividends)
     {
         // Reference via generic Knuth D path with div_limbs=2
-        U256 q_generic = U256::div_large(lhs, divisor, 2);
+        U256 q_generic = TestAccess<U256>::div_large(lhs, divisor, 2);
         // Fast path result via operator/ (which dispatches to div_large_2)
         U256 q_fast = lhs / divisor;
         // Also call the fast specialization directly
-        U256 q_direct = U256::div_large_2(lhs, divisor);
+        U256 q_direct = TestAccess<U256>::div_large_2(lhs, divisor);
 
         EXPECT_EQ(q_fast, q_generic);
         EXPECT_EQ(q_direct, q_generic);
@@ -339,10 +340,10 @@ TEST(WideIntegerDivision, TwoLimbBorrowHighBitCritical)
     U256 rhs = make_u256(0x0000000000000000ULL, 0x0000000000000000ULL, 0xc78b9c3b4b3ccf86ULL, 0x336746e82c1b0b1bULL);
 
     // Reference via generic path with div_limbs=2
-    U256 q_generic = U256::div_large(lhs, rhs, 2);
+    U256 q_generic = TestAccess<U256>::div_large(lhs, rhs, 2);
     // Fast path result
     U256 q_fast = lhs / rhs;
-    U256 q_direct = U256::div_large_2(lhs, rhs);
+    U256 q_direct = TestAccess<U256>::div_large_2(lhs, rhs);
 
     EXPECT_EQ(q_fast, q_generic);
     EXPECT_EQ(q_direct, q_generic);
@@ -364,9 +365,9 @@ TEST(WideIntegerDivision, TwoLimbBorrowLowPartCritical)
     U256 lhs = make_u256(0xfefc33e114ad27f3ULL, 0xfcd67a5601f5602aULL, 0x48742c5441466274ULL, 0xf6153b4fa7293ff0ULL);
     U256 rhs = make_u256(0x0000000000000000ULL, 0x0000000000000000ULL, 0x885c52cdadfc8ea0ULL, 0xc1f885eafdfcb690ULL);
 
-    U256 q_generic = U256::div_large(lhs, rhs, 2);
+    U256 q_generic = TestAccess<U256>::div_large(lhs, rhs, 2);
     U256 q_fast = lhs / rhs;
-    U256 q_direct = U256::div_large_2(lhs, rhs);
+    U256 q_direct = TestAccess<U256>::div_large_2(lhs, rhs);
     U256 r_generic = lhs - q_generic * rhs;
     U256 r_fast = lhs - q_fast * rhs;
 
@@ -604,7 +605,7 @@ TEST(WideIntegerDivision, Div128SingleLimbPath)
     using U64 = gint::integer<64, unsigned>;
     U64 a = 123456789ULL;
     U64 b = 12345ULL;
-    U64 q = U64::div_128(a, b);
+    U64 q = TestAccess<U64>::div_128(a, b);
     EXPECT_EQ(static_cast<uint64_t>(q), static_cast<uint64_t>(a) / static_cast<uint64_t>(b));
 }
 
@@ -612,14 +613,14 @@ TEST(WideIntegerDivision, DivLargeBreak)
 {
     using U192 = gint::integer<192, unsigned>;
     U192 lhs;
-    lhs.data_[0] = 0;
-    lhs.data_[1] = 0xffffffffffffffffULL;
-    lhs.data_[2] = 1;
+    TestAccess<U192>::limb(lhs, 0) = 0;
+    TestAccess<U192>::limb(lhs, 1) = 0xffffffffffffffffULL;
+    TestAccess<U192>::limb(lhs, 2) = 1;
     U192 divisor;
-    divisor.data_[0] = 0xffffffffffffffffULL;
-    divisor.data_[1] = 0xffffffffffffffffULL;
-    divisor.data_[2] = 0;
-    U192 q = U192::div_large(lhs, divisor, 2);
+    TestAccess<U192>::limb(divisor, 0) = 0xffffffffffffffffULL;
+    TestAccess<U192>::limb(divisor, 1) = 0xffffffffffffffffULL;
+    TestAccess<U192>::limb(divisor, 2) = 0;
+    U192 q = TestAccess<U192>::div_large(lhs, divisor, 2);
     EXPECT_EQ(static_cast<uint64_t>(q), 1ULL);
 }
 
@@ -696,9 +697,9 @@ TEST(WideIntegerDivision, ThreeLimbFastPathMatchesGeneric)
 
     for (const auto & lhs : dividends)
     {
-        U256 q_generic = U256::div_large(lhs, divisor, 3);
+        U256 q_generic = TestAccess<U256>::div_large(lhs, divisor, 3);
         U256 q_fast = lhs / divisor; // dispatches to div_large_3
-        U256 q_direct = U256::div_large_3(lhs, divisor);
+        U256 q_direct = TestAccess<U256>::div_large_3(lhs, divisor);
         EXPECT_EQ(q_fast, q_generic);
         EXPECT_EQ(q_direct, q_generic);
     }
@@ -736,7 +737,7 @@ TEST(WideIntegerDivision, HighestBitZeroReturnsMinusOne)
 {
     using U256 = gint::integer<256, unsigned>;
     U256 zero = 0;
-    EXPECT_EQ(zero.highest_bit(), -1);
+    EXPECT_EQ(TestAccess<U256>::highest_bit(zero), -1);
 }
 
 TEST(WideIntegerDivision, UnsignedDivision_MinValueBranches)
@@ -744,35 +745,35 @@ TEST(WideIntegerDivision, UnsignedDivision_MinValueBranches)
     using S256 = gint::integer<256, signed>;
     const S256 min = std::numeric_limits<S256>::min();
 
-    EXPECT_TRUE(S256::is_min_value(min));
-    EXPECT_FALSE(S256::is_min_value(-(S256(1) << 200)));
+    EXPECT_TRUE(TestAccess<S256>::is_min_value(min));
+    EXPECT_FALSE(TestAccess<S256>::is_min_value(-(S256(1) << 200)));
 
     // divisor_limbs == 1
-    S256 q_one = S256::div_unsigned_path(min, S256(1), true, false, true, false);
+    S256 q_one = TestAccess<S256>::div_unsigned_path(min, S256(1), true, false, true, false);
     EXPECT_EQ(q_one, min);
 
     // power-of-two divisor
     S256 pow_div = S256(1) << 120;
-    S256 q_pow = S256::div_unsigned_path(min, pow_div, true, false, true, false);
+    S256 q_pow = TestAccess<S256>::div_unsigned_path(min, pow_div, true, false, true, false);
     EXPECT_EQ(q_pow, -(S256(1) << 135));
 
     // rhs_is_min handling
     S256 rhs_min = min;
     S256 small = 123;
-    S256 q_rhs_min = S256::div_unsigned_path(small, rhs_min, false, true, false, true);
+    S256 q_rhs_min = TestAccess<S256>::div_unsigned_path(small, rhs_min, false, true, false, true);
     EXPECT_EQ(q_rhs_min, S256(0));
 
     // divisor_limbs == 2
     S256 two_limb = (S256(1) << 96) + S256(7);
-    EXPECT_EQ(S256::div_unsigned_path(min, two_limb, true, false, true, false), min / two_limb);
+    EXPECT_EQ(TestAccess<S256>::div_unsigned_path(min, two_limb, true, false, true, false), min / two_limb);
 
     // divisor_limbs == 3
     S256 three_limb = (S256(1) << 180) + (S256(1) << 100) + S256(9);
-    EXPECT_EQ(S256::div_unsigned_path(min, three_limb, true, false, true, false), min / three_limb);
+    EXPECT_EQ(TestAccess<S256>::div_unsigned_path(min, three_limb, true, false, true, false), min / three_limb);
 
     // generic div_large path (divisor_limbs == 4)
     S256 four_limb = (S256(1) << 240) + (S256(1) << 128) + (S256(1) << 64) + S256(11);
-    EXPECT_EQ(S256::div_unsigned_path(min, four_limb, true, false, true, false), min / four_limb);
+    EXPECT_EQ(TestAccess<S256>::div_unsigned_path(min, four_limb, true, false, true, false), min / four_limb);
 }
 
 TEST(WideIntegerDivision, UnsignedDivision_MinValueSmallType)
@@ -780,16 +781,16 @@ TEST(WideIntegerDivision, UnsignedDivision_MinValueSmallType)
     using S128 = gint::integer<128, signed>;
     const S128 min = std::numeric_limits<S128>::min();
     S128 divisor = (S128(1) << 80) + S128(5);
-    EXPECT_EQ(S128::div_unsigned_path(min, divisor, true, false, true, false), min / divisor);
+    EXPECT_EQ(TestAccess<S128>::div_unsigned_path(min, divisor, true, false, true, false), min / divisor);
 }
 
 TEST(WideIntegerDivision, IsMinValueRejectsNonZeroLowLimbs)
 {
     using S256 = gint::integer<256, signed>;
     S256 candidate;
-    candidate.data_[3] = static_cast<uint64_t>(1ULL << 63);
-    candidate.data_[0] = 1;
-    EXPECT_FALSE(S256::is_min_value(candidate));
+    TestAccess<S256>::limb(candidate, 3) = static_cast<uint64_t>(1ULL << 63);
+    TestAccess<S256>::limb(candidate, 0) = 1;
+    EXPECT_FALSE(TestAccess<S256>::is_min_value(candidate));
 }
 
 TEST(WideIntegerDivision, DivLarge2EarlyReturnForShortDividend)
@@ -797,7 +798,7 @@ TEST(WideIntegerDivision, DivLarge2EarlyReturnForShortDividend)
     using U256 = gint::integer<256, unsigned>;
     U256 lhs = 5;
     U256 divisor = (U256(1) << 70) + (U256(1) << 5); // two-limb divisor
-    U256 q = U256::div_large_2(lhs, divisor);
+    U256 q = TestAccess<U256>::div_large_2(lhs, divisor);
     EXPECT_EQ(q, U256(0));
 }
 
@@ -806,7 +807,7 @@ TEST(WideIntegerDivision, DivLarge2StubSingleLimbType)
     using U64 = gint::integer<64, unsigned>;
     U64 lhs = 9;
     U64 divisor = 2;
-    EXPECT_EQ(U64::div_large_2(lhs, divisor), U64::div_large(lhs, divisor, 2));
+    EXPECT_EQ(TestAccess<U64>::div_large_2(lhs, divisor), TestAccess<U64>::div_large(lhs, divisor, 2));
 }
 
 TEST(WideIntegerDivision, DivLarge3StubTwoLimbType)
@@ -814,24 +815,24 @@ TEST(WideIntegerDivision, DivLarge3StubTwoLimbType)
     using U128 = gint::integer<128, unsigned>;
     U128 lhs = (U128(1) << 96) + U128(5);
     U128 divisor = (U128(1) << 64) + U128(3);
-    EXPECT_EQ(U128::div_large_3(lhs, divisor), U128::div_large(lhs, divisor, 3));
+    EXPECT_EQ(TestAccess<U128>::div_large_3(lhs, divisor), TestAccess<U128>::div_large(lhs, divisor, 3));
 }
 
 TEST(WideIntegerDivision, DivLargeGeneric_AddbackBranch)
 {
     using U256 = gint::integer<256, unsigned>;
     U256 lhs;
-    lhs.data_[0] = 15319920140141428228ULL;
-    lhs.data_[1] = 6844823494456829948ULL;
-    lhs.data_[2] = 8650597808387393596ULL;
-    lhs.data_[3] = 16347772628613761532ULL;
+    TestAccess<U256>::limb(lhs, 0) = 15319920140141428228ULL;
+    TestAccess<U256>::limb(lhs, 1) = 6844823494456829948ULL;
+    TestAccess<U256>::limb(lhs, 2) = 8650597808387393596ULL;
+    TestAccess<U256>::limb(lhs, 3) = 16347772628613761532ULL;
 
     U256 divisor;
-    divisor.data_[0] = 2642655789404796171ULL;
-    divisor.data_[1] = 12954822196855299360ULL;
-    divisor.data_[2] = 10810217670908235955ULL;
+    TestAccess<U256>::limb(divisor, 0) = 2642655789404796171ULL;
+    TestAccess<U256>::limb(divisor, 1) = 12954822196855299360ULL;
+    TestAccess<U256>::limb(divisor, 2) = 10810217670908235955ULL;
 
-    U256 q = U256::div_large(lhs, divisor, 3);
+    U256 q = TestAccess<U256>::div_large(lhs, divisor, 3);
     U256 expected = lhs / divisor;
     EXPECT_EQ(q, expected);
     U256 r = lhs - q * divisor;
@@ -843,28 +844,28 @@ TEST(WideIntegerDivision, DivLarge3EarlyReturnWhenDividendShorter)
     using U256 = gint::integer<256, unsigned>;
     U256 lhs = 5;
     U256 divisor;
-    divisor.data_[0] = 1;
-    divisor.data_[1] = 2;
-    divisor.data_[2] = static_cast<uint64_t>(1ULL << 63); // keep three-limb divisor
+    TestAccess<U256>::limb(divisor, 0) = 1;
+    TestAccess<U256>::limb(divisor, 1) = 2;
+    TestAccess<U256>::limb(divisor, 2) = static_cast<uint64_t>(1ULL << 63); // keep three-limb divisor
 
-    EXPECT_EQ(U256::div_large_3(lhs, divisor), U256(0));
+    EXPECT_EQ(TestAccess<U256>::div_large_3(lhs, divisor), U256(0));
 }
 
 TEST(WideIntegerDivision, DivLarge2Generic_AddbackBranch)
 {
     using U320 = gint::integer<320, unsigned>;
     U320 lhs;
-    lhs.data_[0] = 14627284802991019572ULL;
-    lhs.data_[1] = 10210465436952577038ULL;
-    lhs.data_[2] = 4609778614729378691ULL;
-    lhs.data_[3] = 7741901622370343826ULL;
-    lhs.data_[4] = 10933104939142465497ULL;
+    TestAccess<U320>::limb(lhs, 0) = 14627284802991019572ULL;
+    TestAccess<U320>::limb(lhs, 1) = 10210465436952577038ULL;
+    TestAccess<U320>::limb(lhs, 2) = 4609778614729378691ULL;
+    TestAccess<U320>::limb(lhs, 3) = 7741901622370343826ULL;
+    TestAccess<U320>::limb(lhs, 4) = 10933104939142465497ULL;
 
     U320 divisor;
-    divisor.data_[0] = 13705805734369151841ULL;
-    divisor.data_[1] = 12445310395029312220ULL;
+    TestAccess<U320>::limb(divisor, 0) = 13705805734369151841ULL;
+    TestAccess<U320>::limb(divisor, 1) = 12445310395029312220ULL;
 
-    U320 q = U320::div_large_2(lhs, divisor);
+    U320 q = TestAccess<U320>::div_large_2(lhs, divisor);
     U320 expected = lhs / divisor;
     EXPECT_EQ(q, expected);
     U320 r = lhs - q * divisor;
@@ -898,12 +899,12 @@ TEST(WideIntegerDivision, MinValueUnsignedPathSignCorrection)
 
     S256 q = min / divisor;
     S256 r = min % divisor;
-    EXPECT_TRUE(static_cast<int64_t>(q.data_[S256::limbs - 1] >> 63)); // quotient should be negative
+    EXPECT_TRUE(static_cast<int64_t>(TestAccess<S256>::limb(q, S256::limbs - 1) >> 63)); // quotient should be negative
     EXPECT_EQ(q * divisor + r, min);
 
     S256 neg_divisor = -divisor;
     S256 q2 = min / neg_divisor;
     S256 r2 = min % neg_divisor;
-    EXPECT_FALSE(static_cast<int64_t>(q2.data_[S256::limbs - 1] >> 63)); // quotient should be non-negative
+    EXPECT_FALSE(static_cast<int64_t>(TestAccess<S256>::limb(q2, S256::limbs - 1) >> 63)); // quotient should be non-negative
     EXPECT_EQ(q2 * neg_divisor + r2, min);
 }

--- a/tests/float_interop_edge_test.cpp
+++ b/tests/float_interop_edge_test.cpp
@@ -1,9 +1,10 @@
 #include <cmath>
 #include <limits>
-#define private public
 #include <gint/gint.h>
-#undef private
 #include <gtest/gtest.h>
+
+template <typename Int>
+using TestAccess = gint::detail::integer_test_access<Int::bits, typename Int::signed_tag>;
 
 TEST(FloatInteropEdges, NaNComparisons)
 {
@@ -225,9 +226,9 @@ TEST(FloatInteropEdges, CompareWithFloatAbsInternal)
 {
     using U256 = gint::integer<256, unsigned>;
     // rhs_abs == 0 path returns lhs_abs > 0
-    EXPECT_EQ(U256::compare_with_float_abs(U256(5), 0.0), 1);
+    EXPECT_EQ(TestAccess<U256>::compare_with_float_abs(U256(5), 0.0), 1);
     // sigA > sigB branch
-    EXPECT_EQ(U256::compare_with_float_abs(U256(3), 2.0), 1);
+    EXPECT_EQ(TestAccess<U256>::compare_with_float_abs(U256(3), 2.0), 1);
 }
 
 TEST(FloatInteropEdges, EqualitySignMismatch)


### PR DESCRIPTION
标题：fix: 稳定除零检查的跨 TU 行为并清理测试访问方式

问题描述
- 现象：
  - 当某个 TU 定义 `GINT_ENABLE_DIVZERO_CHECKS` 而另一个 TU 未定义时，除零检查是否生效会受链接顺序影响（ODR 相关行为不稳定）。
  - 测试通过 `#define private public` 访问私有实现，存在脆弱性并可能干扰头文件封装语义。
  - `assign(T)` 中对负有符号数的右移依赖实现定义行为。
- 期望：
  - 只要任一 TU 启用 `GINT_ENABLE_DIVZERO_CHECKS`，全程序运行时一致启用除零检查。
  - 测试应使用显式测试访问通道，不破坏封装。
  - `assign(T)` 不依赖实现定义的有符号右移行为。
- 影响面：
  - 主要涉及除法/取模除零检查、测试辅助访问路径、以及有符号原生整数赋值路径。

根因分析
- 代码位置：`include/gint/gint.h`、`tests/arithmetic_divmod_test.cpp`、`tests/float_interop_edge_test.cpp`、`CMakeLists.txt`。
- 触发条件：
  - 多 TU 混合编译宏定义不一致时，链接合并导致除零检查行为不稳定。
  - 测试使用 `private public` 宏重写访问控制。
  - 编译器/平台对负数右移语义差异。

修复方案
- 方案说明：
  - 在头文件内引入统一的全局开关与注册器逻辑，`GINT_ZERO_CHECK` 统一改为查询运行时全局状态，消除链接顺序导致的不确定性。
  - 增加 `GINT_TEST_ACCESS` 下的受控测试访问器（friend + test access 类），替代 `private public` 黑魔法。
  - 重写 `assign(T)` 路径，使用无符号中间值与显式符号扩展填充，避免实现定义右移。
- 兼容性：
  - 公共 API 未新增破坏性变更；行为变化属于 Bug 修正（使语义稳定且可预期）。

测试与验证
- 新增/更新测试：
  - 更新 `tests/arithmetic_divmod_test.cpp`、`tests/float_interop_edge_test.cpp` 以使用 `GINT_TEST_ACCESS`。
- 本地验证：
  - `make TEST_BUILD_DIR=runs/local/build-test test`：`172/172` 通过。
- 容器验证：
  - `gint:centos8` 中构建 C++11 + C++17 测试：`344/344` 通过。
- 回归风险（性能）：
  - 本地 full：`runs/local/bench_compare_full.txt`，`geo_mean_delta_pct=-0.578%`。
  - 本地 Div 聚焦：`runs/local/bench_compare_div.txt`，`geo_mean_delta_pct=-1.224%`。
  - 容器 full（3 次重复取中位数）：`runs/docker/bench_compare_full_median3.txt`，`GEOMEAN_DELTA_PERCENT_MEDIAN=-0.317790622610`。

清单（提交前请逐项勾选）
- [x] 分支名为英文（PR 指南要求）
- [x] 已运行 clang-format（使用仓库根目录 `.clang-format`）
- [x] 新增/更新了回归测试，`make test` 通过
- [x] 修复遵循既有语义：严格位宽、补码、移位、比较与模算术
- [x] 不改变公共 API（除非是对既有行为错误的更正）
- [x] 若触及性能关键路径，已确认无显著回退或已给出数据
- [x] 如变更文档/注释，已同步更新 `docs/` 或注释（本次不涉及）
