### PR TITLE
ci: run benchmark smoke in release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
           fi
 
   benchmark:
+    name: benchmark smoke
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -126,10 +127,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake build-essential libfmt-dev libbenchmark-dev libboost-dev
       - name: Configure
-        run: cmake -S . -B build -DGINT_BUILD_TESTS=OFF -DGINT_BUILD_BENCHMARKS=ON
+        run: cmake -S . -B runs/ci/build-benchmark-smoke -DCMAKE_BUILD_TYPE=Release -DGINT_BUILD_TESTS=OFF -DGINT_BUILD_BENCHMARKS=ON
       - name: Build
-        run: cmake --build build --config Release --parallel
-      - name: Run benchmarks
+        run: cmake --build runs/ci/build-benchmark-smoke --parallel
+      - name: Run benchmark smoke tests
         run: |
-          build/perf_benchmark_int256 --benchmark_min_time=0.01s
-          build/perf_compare_int256 --benchmark_min_time=0.01s
+          # Smoke only: keep this short. Use local runs or a dedicated perf workflow for performance conclusions.
+          runs/ci/build-benchmark-smoke/perf_benchmark_int256 --benchmark_min_time=0.01s
+          runs/ci/build-benchmark-smoke/perf_compare_int256 --benchmark_min_time=0.01s


### PR DESCRIPTION
## 范围
- 修改 CI 中现有 `benchmark` job 的定位和构建方式。
- 不新增正式性能结论 workflow，本 PR 只把当前短采样 benchmark 明确为 smoke test。

## 内容摘要
- 将 job 显示名改为 `benchmark smoke`，避免把短采样 Actions 输出误读成性能结论。
- `Configure` 阶段显式传入 `-DCMAKE_BUILD_TYPE=Release`，修复 Linux 单配置生成器下 `cmake --build --config Release` 不生效的问题。
- benchmark 构建目录改为 `runs/ci/build-benchmark-smoke`，符合项目产物目录约定。
- 运行步骤改名为 `Run benchmark smoke tests`，保留 `--benchmark_min_time=0.01s`，并在 workflow 注释中说明只用于 smoke。

## 验证
- 本地按新 CI 命令配置：`cmake -S . -B runs/ci/build-benchmark-smoke -DCMAKE_BUILD_TYPE=Release -DGINT_BUILD_TESTS=OFF -DGINT_BUILD_BENCHMARKS=ON`
- 本地按新 CI 命令构建：`cmake --build runs/ci/build-benchmark-smoke --parallel`
- 本地按新 CI 命令运行：
  - `runs/ci/build-benchmark-smoke/perf_benchmark_int256 --benchmark_min_time=0.01s`
  - `runs/ci/build-benchmark-smoke/perf_compare_int256 --benchmark_min_time=0.01s`
- 运行输出不再出现 `***WARNING*** Library was built as DEBUG. Timings may be affected.`
- `git diff --check` 通过。

## 清单
- [x] 分支名为英文（PR 指南要求）
- [x] 文档与实现/测试一致（避免漂移）
- [x] 未更改公共 API
- [x] 已运行必要的示例/命令验证