### PR TITLE
fix: guard unchecked zero division

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,35 @@ if(GINT_BUILD_TESTS)
         )
     endif()
 
+    add_executable(gint_tests_no_divzero_checks tests/divzero_unchecked_test.cpp)
+    target_include_directories(gint_tests_no_divzero_checks PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    set_target_properties(gint_tests_no_divzero_checks PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
+    target_compile_options(gint_tests_no_divzero_checks PRIVATE ${GINT_TEST_OPTIONS})
+    if(GINT_TEST_LINK_OPTIONS)
+        target_link_options(gint_tests_no_divzero_checks PRIVATE ${GINT_TEST_LINK_OPTIONS})
+    endif()
+    target_link_libraries(gint_tests_no_divzero_checks PRIVATE GTest::gtest_main)
+    gtest_discover_tests(gint_tests_no_divzero_checks
+        TEST_PREFIX no_divzero_checks.
+        NO_PRETTY_VALUES
+        DISCOVERY_TIMEOUT 60
+    )
+
+    add_executable(gint_tests_no_divzero_checks_fastpaths tests/divzero_unchecked_test.cpp)
+    target_include_directories(gint_tests_no_divzero_checks_fastpaths PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    set_target_properties(gint_tests_no_divzero_checks_fastpaths PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
+    target_compile_options(gint_tests_no_divzero_checks_fastpaths PRIVATE ${GINT_TEST_OPTIONS})
+    target_compile_definitions(gint_tests_no_divzero_checks_fastpaths PRIVATE GINT_ENABLE_POSITIVE_LIMB_DIV_FASTPATH=1 GINT_ENABLE_DIRECT_LARGE_MOD=1)
+    if(GINT_TEST_LINK_OPTIONS)
+        target_link_options(gint_tests_no_divzero_checks_fastpaths PRIVATE ${GINT_TEST_LINK_OPTIONS})
+    endif()
+    target_link_libraries(gint_tests_no_divzero_checks_fastpaths PRIVATE GTest::gtest_main)
+    gtest_discover_tests(gint_tests_no_divzero_checks_fastpaths
+        TEST_PREFIX no_divzero_checks_fastpaths.
+        NO_PRETTY_VALUES
+        DISCOVERY_TIMEOUT 60
+    )
+
     # Optionally compile the full unit test suite under C++17 when explicitly enabled
     if(GINT_BUILD_TESTS_CXX17)
         check_cxx_compiler_flag("-std=c++17" HAS_CXX17)

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1405,6 +1405,8 @@ public:
     friend integer operator/(integer lhs, signed_limb_type rhs)
     {
         GINT_DIVZERO_CHECK(rhs == 0);
+        if (GINT_UNLIKELY(rhs == 0))
+            return integer();
         // For unsigned integers, mimic native casts: reinterpret negative divisors as their two's complement magnitude.
         if (std::is_same<Signed, unsigned>::value && rhs < 0)
             return lhs / integer(rhs);
@@ -1447,6 +1449,8 @@ public:
     friend integer operator%(integer lhs, signed_limb_type rhs)
     {
         GINT_MODZERO_CHECK(rhs == 0);
+        if (GINT_UNLIKELY(rhs == 0))
+            return lhs;
         // For unsigned integers, mimic native casts: reinterpret negative divisors as their two's complement magnitude.
         if (std::is_same<Signed, unsigned>::value && rhs < 0)
             return lhs % integer(rhs);
@@ -1500,6 +1504,8 @@ public:
     friend integer operator%(integer lhs, T rhs)
     {
         GINT_MODZERO_CHECK(rhs == 0);
+        if (GINT_UNLIKELY(rhs == 0))
+            return lhs;
         // For unsigned integers, mimic native casts: reinterpret negative divisors as their two's complement magnitude.
         if (std::is_same<Signed, unsigned>::value && detail::is_signed<T>::value && rhs < 0)
             return lhs % integer(rhs);
@@ -2310,7 +2316,7 @@ private:
         limb_type high_or = 0;
         for (size_t i = 1; i < limbs; ++i)
             high_or |= v.data_[i];
-        return high_or == 0;
+        return value != 0 && high_or == 0;
     }
 
     static integer div_by_positive_limb(integer lhs, limb_type divisor) noexcept
@@ -2460,8 +2466,10 @@ private:
     {
         unsigned __int128 a = (static_cast<unsigned __int128>(lhs.data_[1]) << 64) | lhs.data_[0];
         unsigned __int128 b = (static_cast<unsigned __int128>(rhs.data_[1]) << 64) | rhs.data_[0];
-        unsigned __int128 q = a / b;
         integer result;
+        if (GINT_UNLIKELY(b == 0))
+            return result;
+        unsigned __int128 q = a / b;
         result.data_[0] = static_cast<limb_type>(q);
         result.data_[1] = static_cast<limb_type>(q >> 64);
         return result;
@@ -2471,6 +2479,8 @@ private:
     static typename std::enable_if<(L < 2), integer>::type div_128(const integer & lhs, const integer & rhs) noexcept
     {
         integer result;
+        if (GINT_UNLIKELY(rhs.data_[0] == 0))
+            return result;
         result.data_[0] = lhs.data_[0] / rhs.data_[0];
         return result;
     }
@@ -2504,7 +2514,7 @@ private:
         size_t n = limbs;
         while (n > 0 && lhs.data_[n - 1] == 0)
             --n;
-        if (n < div_limbs)
+        if (GINT_UNLIKELY(div_limbs == 0) || n < div_limbs)
             return quotient;
 
         std::array<limb_type, limbs + 1> u = {};

--- a/tests/divzero_unchecked_test.cpp
+++ b/tests/divzero_unchecked_test.cpp
@@ -1,0 +1,77 @@
+#include <cstdint>
+#include <limits>
+
+#include <gint/gint.h>
+#include <gtest/gtest.h>
+
+TEST(WideIntegerDivModUnchecked, UnsignedIntegerZeroDivisor)
+{
+    using U64 = gint::integer<64, unsigned>;
+    using U128 = gint::integer<128, unsigned>;
+    using U512 = gint::integer<512, unsigned>;
+
+    const U64 u64 = 123;
+    const U64 z64 = 0;
+    EXPECT_EQ(u64 / z64, U64(0));
+    EXPECT_EQ(u64 % z64, u64);
+
+    const U128 u128 = (U128(1) << 100) + U128(123);
+    const U128 z128 = 0;
+    EXPECT_EQ(u128 / z128, U128(0));
+    EXPECT_EQ(u128 % z128, u128);
+
+    const U512 u512 = (U512(1) << 300) + U512(123);
+    const U512 z512 = 0;
+    EXPECT_EQ(u512 / z512, U512(0));
+    EXPECT_EQ(u512 % z512, u512);
+}
+
+TEST(WideIntegerDivModUnchecked, SignedIntegerZeroDivisor)
+{
+    using S128 = gint::integer<128, signed>;
+    using S512 = gint::integer<512, signed>;
+
+    const S128 min128 = std::numeric_limits<S128>::min();
+    const S128 z128 = 0;
+    EXPECT_EQ(min128 / z128, S128(0));
+    EXPECT_EQ(min128 % z128, min128);
+
+    const S512 value = -((S512(1) << 300) + S512(123));
+    const S512 z512 = 0;
+    EXPECT_EQ(value / z512, S512(0));
+    EXPECT_EQ(value % z512, value);
+}
+
+TEST(WideIntegerDivModUnchecked, ScalarZeroDivisor)
+{
+    using U512 = gint::integer<512, unsigned>;
+    using S512 = gint::integer<512, signed>;
+
+    const U512 u = (U512(1) << 300) + U512(123);
+    const std::uint64_t u64_zero = 0;
+    const int int_zero = 0;
+
+    EXPECT_EQ(u / u64_zero, U512(0));
+    EXPECT_EQ(u % u64_zero, u);
+    EXPECT_EQ(u / int_zero, U512(0));
+    EXPECT_EQ(u % int_zero, u);
+
+    const S512 s = -((S512(1) << 300) + S512(123));
+    const std::int64_t i64_zero = 0;
+    EXPECT_EQ(s / i64_zero, S512(0));
+    EXPECT_EQ(s % i64_zero, s);
+}
+
+TEST(WideIntegerDivModUnchecked, FloatingZeroDivisor)
+{
+    using U512 = gint::integer<512, unsigned>;
+    using S512 = gint::integer<512, signed>;
+
+    const U512 u = (U512(1) << 300) + U512(123);
+    EXPECT_EQ(u / 0.0, U512(0));
+    EXPECT_EQ(u % 0.0, u);
+
+    const S512 s = -((S512(1) << 300) + S512(123));
+    EXPECT_EQ(s / 0.0, S512(0));
+    EXPECT_EQ(s % 0.0, s);
+}


### PR DESCRIPTION
## 问题

- 现象：关闭 `GINT_ENABLE_DIVZERO_CHECKS` 时，`integer / 0`、`integer % 0` 以及标量/浮点零除数路径仍可能进入 `div_large(..., div_limbs=0)`、`div_128(..., 0)` 或 `div_mod_small(0)`，触发 OOB/UB。
- 根因：除零检查宏在 checks 关闭时只是不抛异常，不会改变控制流；最新 fast path 还会把 0 识别为 positive single-limb divisor，direct mod fast path 也缺少零除数兜底。

## 修复

- 将 0 从 positive-limb division fast path 排除，避免落入 `div_mod_small(0)`。
- 在 `div_128` 与 `div_large` 的冷路径上兜底 0 divisor，使 checks 关闭时 `/ 0` 返回 0。
- 在标量 `% 0` 与小整数 `/ 0` 路径上补齐 checks-off 行为，使 `% 0` 返回被除数。
- 新增独立 checks-off 测试目标，并额外覆盖强制打开 `GINT_ENABLE_POSITIVE_LIMB_DIV_FASTPATH` 与 `GINT_ENABLE_DIRECT_LARGE_MOD` 的组合。

## 验证

- `clang-format -i include/gint/gint.h tests/divzero_unchecked_test.cpp`
- ASan/UBSan 最小复现：默认路径与强制 fast path 路径均返回 `/0 -> 0`、`%0 -> lhs`，无 sanitizer 报错。
- `make TEST_BUILD_DIR=runs/local/build-test test`：352/352 passed。
- `git diff --check`
- 性能：本机 AppleClang，`bench-full`，过滤器 `^(Div|Mod)/`，`--benchmark_min_time=1s`。基线 `09cd1d7`，结果文件：
  - `runs/local/divmod_zero_guard_baseline_1s.json`
  - `runs/local/divmod_zero_guard_result_1s.json`
- 结论：Div/Mod 用例未出现系统性回退，最慢项约 +0.70%，其余在本机微基准抖动范围内或更快。

## 风险

- 行为变更仅限关闭除零检查时的零除数路径；开启 `GINT_ENABLE_DIVZERO_CHECKS` 时仍抛出 `std::domain_error`。
- 当前性能验证仅覆盖默认要求的本机 AppleClang 环境；未额外跑 Docker/GCC。
