### PR TITLE
perf: speed up GCC division sign handling

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1426,7 +1426,7 @@ public:
                 if (GINT_UNLIKELY(lhs.data_[limbs - 1] == min_magnitude && is_min_value(lhs)))
                     lhs_is_min = true;
                 else
-                    lhs = -lhs;
+                    negate_for_division(lhs);
             }
             // 同理对除数执行一次最高 limb 检查，保持正负号拆分与检测逻辑一致。
             if (rhs_neg)
@@ -1434,7 +1434,7 @@ public:
                 if (GINT_UNLIKELY(divisor.data_[limbs - 1] == min_magnitude && is_min_value(divisor)))
                     rhs_is_min = true;
                 else
-                    divisor = -divisor;
+                    negate_for_division(divisor);
             }
             if (GINT_UNLIKELY(lhs_is_min || rhs_is_min))
                 return div_unsigned_path(lhs, divisor, lhs_neg, rhs_neg, lhs_is_min, rhs_is_min);
@@ -1480,7 +1480,7 @@ public:
             }
         }
         if (std::is_same<Signed, signed>::value && lhs_neg != rhs_neg)
-            result = -result;
+            negate_for_division(result);
         return result;
     }
 
@@ -2303,7 +2303,7 @@ private:
         bool lhs_neg = false;
         if (std::is_same<Signed, signed>::value && (tmp.data_[limbs - 1] >> 63))
         {
-            tmp = -tmp;
+            negate_for_division(tmp);
             lhs_neg = true;
         }
         bool div_neg = div < 0;
@@ -2314,7 +2314,7 @@ private:
         if (lhs_neg)
             rem = -rem;
         if (lhs_neg != div_neg)
-            quotient = -quotient;
+            negate_for_division(quotient);
         return rem;
     }
 
@@ -2390,7 +2390,7 @@ private:
             result.data_[i] = quotient_mag.data_[i];
 
         if (lhs_neg != rhs_neg)
-            result = -result;
+            negate_for_division(result);
         return result;
     }
 
@@ -2422,14 +2422,35 @@ private:
         return high_or == 0;
     }
 
+    static GINT_FORCE_INLINE void negate_in_place(integer & v) noexcept
+    {
+        limb_type carry = 1;
+        for (size_t i = 0; i < limbs; ++i)
+        {
+            const limb_type inv = ~v.data_[i];
+            const limb_type sum = inv + carry;
+            v.data_[i] = sum;
+            carry = carry && (sum == 0);
+        }
+    }
+
+    static GINT_FORCE_INLINE void negate_for_division(integer & v) noexcept
+    {
+#if GINT_GCC_TUNED_PATHS
+        negate_in_place(v);
+#else
+        v = -v;
+#endif
+    }
+
     static integer div_by_positive_limb(integer lhs, limb_type divisor) noexcept
     {
         integer result;
         if (std::is_same<Signed, signed>::value && (lhs.data_[limbs - 1] >> 63))
         {
-            lhs = -lhs;
+            negate_for_division(lhs);
             lhs.div_mod_small(divisor, result);
-            result = -result;
+            negate_for_division(result);
             return result;
         }
 
@@ -2446,7 +2467,8 @@ private:
             Unsigned lhs_mag;
             copy_abs_magnitude(lhs_mag, lhs, true);
             result.data_[0] = lhs_mag.mod_small(divisor);
-            return -result;
+            negate_for_division(result);
+            return result;
         }
 
         result.data_[0] = lhs.mod_small(divisor);
@@ -2486,7 +2508,9 @@ private:
         integer result;
         for (size_t i = 0; i < limbs; ++i)
             result.data_[i] = rem_mag.data_[i];
-        return lhs_neg ? -result : result;
+        if (lhs_neg)
+            negate_for_division(result);
+        return result;
     }
 
     static integer rem_unsigned_magnitude(const integer & lhs, const integer & divisor) noexcept


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`^(Div/(SmallDivisor32|SmallDivisor64|LargeDivisor128|SimilarMagnitude2)|Bitwise/Xor)/`
- 环境：本机 AppleClang 21.0.0 与 Docker/GCC 8.5.0，`CMAKE_BUILD_TYPE=Release`
- 目标：优化 Docker/GCC 下 `Div/SmallDivisor32`，避免继续弱于 ClickHouse 和 Boost

## 结果

- Docker/GCC `Div/SmallDivisor32/gint`: `22.07ns -> 8.71ns`，快于 ClickHouse `18.42ns` 和 Boost `19.95ns`
- Docker/GCC `Div/SmallDivisor64/gint`: `19.29ns -> 12.12ns`，快于 ClickHouse `17.88ns` 和 Boost `22.57ns`
- Docker/GCC `Div/LargeDivisor128/gint`: `48.35ns -> 23.80ns`，快于 Boost `34.86ns`
- Docker/GCC `Div/SimilarMagnitude2/gint`: `19.60ns -> 19.60ns`，仍弱于 Boost `17.85ns`
- AppleClang `Bitwise/Xor/gint`: `0.764ns -> 0.759ns`，仍弱于 ClickHouse `0.361ns`
- 结果文件：`runs/local/target_result.json`、`runs/docker/target_result.json`、`runs/local/full_result.json`、`runs/docker/full_result.json`

## 验证

- `git diff --check`
- `make test`：355/355 passed
- `docker run --rm -t -v "$PWD":/work -w /work gint:centos8 make TEST_BUILD_DIR=runs/docker/build test`：355/355 passed
- `bench-compare-full` 目标短集与完整矩阵扫描；本机无阈值回退。Docker/GCC 完整矩阵中 `Shift/LeftVariable` 一次短跑触发阈值，后续同过滤器聚焦复测未复现，且该路径与本次 division 符号处理改动无关。

## 风险

- 新增的 in-place negation 仅在现有 `GINT_GCC_TUNED_PATHS` 下用于 division/modulo 符号修正；Clang 继续使用原 `v = -v` 路径。
- 未新增架构专用分支，未新增性能宏。