### PR TITLE
perf: optimize Int256 full-width division

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ Arithmetic & ToString — 256-bit
 
 | Case                   | gint | ClickHouse | Boost |
 | ---------------------- | ---: | ---------: | ----: |
-| Add/NoCarry            | 0.666 |       1.94 |  4.72 |
-| Add/FullCarry          | 0.661 |       1.84 |  1.77 |
-| Sub/NoBorrow           | 0.664 |       1.59 |  4.81 |
-| Sub/FullBorrow         | 0.658 |       1.76 |  2.04 |
-| Mul/U64xU64            | 1.77 |       2.78 |  2.23 |
-| Mul/HighxHigh          | 1.75 |       2.75 | 10.4 |
-| Div/SmallDivisor32     | 11.1 |       13.7 | 19.7 |
-| Div/Pow2Divisor        | 6.68 |        310 | 66.6 |
-| Div/SimilarMagnitude   | 15.8 |        227 | 65.4 |
-| ToString/Base10        |  125 |        284 |  142 |
+| Add/NoCarry            | 0.677 |       1.84 |  4.90 |
+| Add/FullCarry          | 0.682 |       2.07 |  1.91 |
+| Sub/NoBorrow           | 0.683 |       1.63 |  4.99 |
+| Sub/FullBorrow         | 0.686 |       1.82 |  2.09 |
+| Mul/U64xU64            | 1.86 |       2.89 |  2.34 |
+| Mul/HighxHigh          | 1.83 |       2.85 | 10.7 |
+| Div/SmallDivisor32     | 11.5 |       14.7 | 20.8 |
+| Div/Pow2Divisor        | 6.00 |        316 | 68.8 |
+| Div/SimilarMagnitude   | 13.4 |        237 | 69.3 |
+| ToString/Base10        |  128 |        298 |  148 |
 
 Highlights
-- Add/Sub: ~2.4-2.9x faster vs ClickHouse; ~2.7-7.2x vs Boost.
+- Add/Sub: ~2.4-3.0x faster vs ClickHouse; ~2.8-7.3x vs Boost.
 - Mul: faster than ClickHouse and Boost on the listed 256-bit cases, with the largest gain on high x high.
 - Div: large wins for power-of-two and similar-magnitude divisors; still faster on 32-bit small divisors.
 - ToString: ~1.1x faster vs Boost; ~2.3x vs ClickHouse.
@@ -78,6 +78,8 @@ make coverage
 
 This builds the project with coverage flags, runs the tests, and
 produces a coverage report under the `runs/local/build-coverage` directory.
+For Linux/GCC coverage of GCC-tuned paths, run the same target in the Docker
+image with `COVERAGE_DIR=runs/docker/build-coverage`.
 
 ## Documentation
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -62,8 +62,7 @@
 
 ### 结果（完整矩阵，real_time ns/op）
 
-数值越低越好。以下数据来自 `bench-compare-full` 的本机 AppleClang 样本，结果文件为
-`runs/local/compare_full_after_divlarge4_docs_20260426.json`。
+数值越低越好。以下数据来自 `bench-compare-full` 的本机 AppleClang 样本；如需复现，应按上文命令重新采集当前工作区的本地结果。
 
 #### 加法（Addition）
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -62,7 +62,8 @@
 
 ### 结果（完整矩阵，real_time ns/op）
 
-数值越低越好。以下数据来自 `bench-compare-full` 的本机 AppleClang 样本。
+数值越低越好。以下数据来自 `bench-compare-full` 的本机 AppleClang 样本，结果文件为
+`runs/local/compare_full_after_divlarge4_docs_20260426.json`。
 
 #### 加法（Addition）
 
@@ -73,9 +74,9 @@
 
 | 用例         | gint  | ClickHouse | Boost |
 | ------------ | ----: | ---------: | ----: |
-| NoCarry      | 0.666 |       1.94 |  4.72 |
-| FullCarry    | 0.661 |       1.84 |  1.77 |
-| CarryChain64 | 0.659 |       1.74 |  4.60 |
+| NoCarry      | 0.677 |       1.84 |  4.90 |
+| FullCarry    | 0.682 |       2.07 |  1.91 |
+| CarryChain64 | 0.683 |       1.81 |  4.84 |
 
 #### 减法（Subtraction）
 
@@ -86,9 +87,9 @@
 
 | 用例          | gint  | ClickHouse | Boost |
 | ------------- | ----: | ---------: | ----: |
-| NoBorrow      | 0.664 |       1.59 |  4.81 |
-| FullBorrow    | 0.658 |       1.76 |  2.04 |
-| BorrowChain64 | 0.659 |       1.68 |  4.54 |
+| NoBorrow      | 0.683 |       1.63 |  4.99 |
+| FullBorrow    | 0.686 |       1.82 |  2.09 |
+| BorrowChain64 | 0.681 |       1.67 |  4.91 |
 
 #### 乘法（Multiplication）
 
@@ -100,10 +101,10 @@
 
 | 用例         | gint  | ClickHouse | Boost |
 | ------------ | ----: | ---------: | ----: |
-| U64xU64      |  1.77 |       2.78 |  2.23 |
-| HighxHigh    |  1.75 |       2.75 |  10.4 |
-| WideTimesU64 | 0.889 |       3.22 |  2.51 |
-| U32xWide     |  1.78 |       3.64 |  4.23 |
+| U64xU64      |  1.86 |       2.89 |  2.34 |
+| HighxHigh    |  1.83 |       2.85 |  10.7 |
+| WideTimesU64 | 0.932 |       3.36 |  2.35 |
+| U32xWide     |  1.92 |       3.82 |  4.37 |
 
 #### 除法（Division）
 
@@ -111,29 +112,29 @@
 - SmallDivisor32：被除数为随机 256 位，除数取 32 位范围，覆盖“基数 2^32 的小除数场景”。
 - SmallDivisor64：被除数为随机 256 位，除数取 64 位范围，覆盖“128/64 估商的小除数场景”。
 - Pow2Divisor：除数为 2 的幂，覆盖“移位等价”的极端快路径。
-- SimilarMagnitude：被除数与除数数量级相近，覆盖“Knuth D 多 limb 重路径”，考察规范化与估商修正。
+- SimilarMagnitude：被除数与除数数量级相近，覆盖 256 位满宽除数的单 quotient-limb 快路径，考察规范化与估商修正。
 - LargeDivisor128：两 limb 除数，覆盖“多 limb 路径在 2-limb 情况的热点”。
-- SimilarMagnitude2：与上述相似量级不同分布，用于验证分布差异对分支与规范化的影响。
+- SimilarMagnitude2：与上述相似量级不同分布，同样覆盖满宽除数快路径，用于验证分布差异对分支与规范化的影响。
 
 | 用例                       | gint | ClickHouse | Boost |
 | -------------------------- | ---: | ---------: | ----: |
-| SmallDivisor32（32 位）    | 11.1 |       13.7 |  19.7 |
-| SmallDivisor64（64 位）    | 13.7 |       13.7 |  22.8 |
-| Pow2Divisor（2 的幂）      | 6.68 |        310 |  66.6 |
-| SimilarMagnitude           | 15.8 |        227 |  65.4 |
-| LargeDivisor128（两 limb） | 17.0 |        524 |  36.1 |
-| SimilarMagnitude2          | 14.7 |        205 |  77.6 |
+| SmallDivisor32（32 位）    | 11.5 |       14.7 |  20.8 |
+| SmallDivisor64（64 位）    | 14.1 |       14.6 |  23.6 |
+| Pow2Divisor（2 的幂）      | 6.00 |        316 |  68.8 |
+| SimilarMagnitude           | 13.4 |        237 |  69.3 |
+| LargeDivisor128（两 limb） | 18.2 |        564 |  37.0 |
+| SimilarMagnitude2          | 9.99 |        217 |  83.6 |
 
 #### 取模（Modulo）
 
 **设计**
 - SmallDivisor64：被除数为随机 256 位，除数取 64 位范围，覆盖小除数取模路径。
-- SimilarMagnitude：被除数与除数数量级相近，覆盖多 limb 取模路径。
+- SimilarMagnitude：被除数与除数数量级相近，覆盖满宽除数取模路径。
 
 | 用例             | gint | ClickHouse | Boost |
 | ---------------- | ---: | ---------: | ----: |
-| SmallDivisor64   | 20.5 |       15.3 |  19.0 |
-| SimilarMagnitude | 18.4 |        227 |  65.2 |
+| SmallDivisor64   | 13.1 |       16.1 |  20.7 |
+| SimilarMagnitude | 16.8 |        237 |  68.8 |
 
 #### 位运算（Bitwise）
 
@@ -143,8 +144,8 @@
 
 | 用例 | gint  | ClickHouse | Boost |
 | ---- | ----: | ---------: | ----: |
-| And  | 0.756 |      0.750 |  7.84 |
-| Xor  | 0.750 |      0.354 |  6.96 |
+| And  | 0.779 |      0.778 |  7.64 |
+| Xor  | 0.782 |      0.364 |  7.62 |
 
 #### 移位（Shift）
 
@@ -154,8 +155,8 @@
 
 | 用例          | gint | ClickHouse | Boost |
 | ------------- | ---: | ---------: | ----: |
-| LeftVariable  | 4.31 |       3.20 |  5.65 |
-| RightVariable | 2.78 |       2.99 |  3.73 |
+| LeftVariable  | 1.90 |       3.35 |  6.00 |
+| RightVariable | 1.39 |       3.22 |  3.86 |
 
 #### 字符串转换（ToString）
 
@@ -164,4 +165,4 @@
 
 | 用例   | gint | ClickHouse | Boost |
 | ------ | ---: | ---------: | ----: |
-| Base10 |  125 |        284 |   142 |
+| Base10 |  128 |        298 |   148 |

--- a/docs/TECH_SPEC.md
+++ b/docs/TECH_SPEC.md
@@ -155,6 +155,7 @@
     - 通用实现 `div_large`：只做一次 128/64 除法并以“乘回求余”代替取模，减少除法使用；规范化左移通过内部工具函数 `lshift_limbs_to()` 复用，消除重复代码。
     - 两肢专用 `div_large_2`：定长内核，基于最高 limb 估商，校正最多两次；乘回复用 `qhat*v1 = numerator - rhat` 消去一处乘法。
     - 三肢专用 `div_large_3`：定长内核，复用 `qhat*v[2] = numerator - rhat` 优化；保持 Algorithm D 的估商修正与借位补偿流程。
+    - 四肢专用 `div_large_4`：针对 256 位满宽除数（`divisor_limbs == 4`）且商最多为单 limb 的场景，定长展开规范化、估商修正和乘回减法；`operator/` 与 GCC-tuned 的多 limb `operator%` 路径都会复用该内核。
   - 仍保留移位‑减法（`div_shift_subtract`）作为后备实现，但常规路径不使用。
 - 字符串转换（to_string）：
   - 采用十进制 10^19 分块法：每次除以 10^19 收集一段 19 位十进制块（低位到高位），最后一次性拼接输出（首块不补零，其余块左零填充）。

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -32,6 +32,12 @@
 #    define GINT_CLANG_NOINLINE
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+#    define GINT_NOINLINE __attribute__((noinline))
+#else
+#    define GINT_NOINLINE
+#endif
+
 #define GINT_ZERO_CHECK(cond, msg) \
     do \
     { \
@@ -1473,6 +1479,11 @@ public:
                 // Specialized fast path: three-limb divisor
                 result = div_large_3(lhs, divisor);
             }
+            else if (limbs == 4 && divisor_limbs == 4)
+            {
+                // Specialized fast path: full-width 256-bit divisor produces a single quotient limb.
+                result = div_large_4(lhs, divisor);
+            }
             else
             {
                 // Multi-limb divisor: use Knuth's Algorithm D (div_large)
@@ -2538,6 +2549,8 @@ private:
             quotient = div_large_2(lhs, divisor);
         else if (divisor_limbs == 3)
             quotient = div_large_3(lhs, divisor);
+        else if (limbs == 4 && divisor_limbs == 4)
+            quotient = div_large_4(lhs, divisor);
         else
             quotient = div_large(lhs, divisor, divisor_limbs);
 
@@ -2721,6 +2734,106 @@ private:
             quotient.data_[j] = static_cast<limb_type>(qhat);
         }
         return quotient;
+    }
+
+    // Optimized specialization: full-width 256-bit divisor (divisor_limbs == 4)
+    template <size_t L = limbs>
+    static GINT_NOINLINE typename std::enable_if<(L == 4), integer>::type div_large_4(integer lhs, const integer & divisor) noexcept
+    {
+        integer quotient;
+        if (lhs.data_[3] == 0)
+            return quotient;
+
+        using u128 = unsigned __int128;
+
+        // Normalize divisor so that its top limb has its MSB set.
+        const int shift = __builtin_clzll(divisor.data_[3]);
+        limb_type u0;
+        limb_type u1;
+        limb_type u2;
+        limb_type u3;
+        limb_type u4;
+        limb_type v0;
+        limb_type v1;
+        limb_type v2;
+        limb_type v3;
+
+        if (shift == 0)
+        {
+            u0 = lhs.data_[0];
+            u1 = lhs.data_[1];
+            u2 = lhs.data_[2];
+            u3 = lhs.data_[3];
+            u4 = 0;
+            v0 = divisor.data_[0];
+            v1 = divisor.data_[1];
+            v2 = divisor.data_[2];
+            v3 = divisor.data_[3];
+        }
+        else
+        {
+            const int inv_shift = 64 - shift;
+            u0 = lhs.data_[0] << shift;
+            u1 = (lhs.data_[1] << shift) | (lhs.data_[0] >> inv_shift);
+            u2 = (lhs.data_[2] << shift) | (lhs.data_[1] >> inv_shift);
+            u3 = (lhs.data_[3] << shift) | (lhs.data_[2] >> inv_shift);
+            u4 = lhs.data_[3] >> inv_shift;
+            v0 = divisor.data_[0] << shift;
+            v1 = (divisor.data_[1] << shift) | (divisor.data_[0] >> inv_shift);
+            v2 = (divisor.data_[2] << shift) | (divisor.data_[1] >> inv_shift);
+            v3 = (divisor.data_[3] << shift) | (divisor.data_[2] >> inv_shift);
+        }
+
+        const u128 numerator = (static_cast<u128>(u4) << 64) | u3;
+        u128 qhat = numerator / v3;
+        u128 rhat = numerator - qhat * v3;
+
+        while (qhat == (static_cast<u128>(1) << 64) || qhat * v2 > ((rhat << 64) | u2))
+        {
+            --qhat;
+            rhat += v3;
+            if (rhat >= (static_cast<u128>(1) << 64))
+                break;
+        }
+
+        u128 borrow = 0;
+        {
+            u128 p = qhat * v0 + borrow;
+            const limb_type p_low = static_cast<limb_type>(p);
+            u0 = static_cast<limb_type>(static_cast<u128>(u0) - p);
+            borrow = (p >> 64) + (u0 > ~p_low);
+        }
+        {
+            u128 p = qhat * v1 + borrow;
+            const limb_type p_low = static_cast<limb_type>(p);
+            u1 = static_cast<limb_type>(static_cast<u128>(u1) - p);
+            borrow = (p >> 64) + (u1 > ~p_low);
+        }
+        {
+            u128 p = qhat * v2 + borrow;
+            const limb_type p_low = static_cast<limb_type>(p);
+            u2 = static_cast<limb_type>(static_cast<u128>(u2) - p);
+            borrow = (p >> 64) + (u2 > ~p_low);
+        }
+        {
+            u128 p = qhat * v3 + borrow;
+            const limb_type p_low = static_cast<limb_type>(p);
+            u3 = static_cast<limb_type>(static_cast<u128>(u3) - p);
+            borrow = (p >> 64) + (u3 > ~p_low);
+        }
+
+        if (static_cast<u128>(u4) < borrow)
+            --qhat;
+
+        quotient.data_[0] = static_cast<limb_type>(qhat);
+        return quotient;
+    }
+
+    // Stub for non-256-bit instantiations to keep dependent calls well-formed.
+    template <size_t L = limbs>
+    static typename std::enable_if<(L != 4), integer>::type div_large_4(integer lhs, const integer & divisor) noexcept
+    {
+        return div_large(lhs, divisor, 4);
     }
 
     // Optimized specialization: two-limb divisor (divisor_limbs == 2)
@@ -3058,6 +3171,8 @@ struct integer_test_access
 
     static Int div_large_3(Int lhs, const Int & rhs) noexcept { return Int::div_large_3(lhs, rhs); }
 
+    static Int div_large_4(Int lhs, const Int & rhs) noexcept { return Int::div_large_4(lhs, rhs); }
+
     template <typename T>
     static int compare_with_float_abs(const Int & lhs_abs, T rhs_abs) noexcept
     {
@@ -3235,6 +3350,7 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_CONSTEXPR14
 #undef GINT_FORCE_INLINE
 #undef GINT_CLANG_NOINLINE
+#undef GINT_NOINLINE
 #undef GINT_RESTRICT
 #undef GINT_HAS_IS_CONSTANT_EVALUATED
 #undef GINT_ENABLE_AARCH64_LIMB_ASM

--- a/tests/arithmetic_divmod_test.cpp
+++ b/tests/arithmetic_divmod_test.cpp
@@ -707,6 +707,55 @@ TEST(WideIntegerDivision, ThreeLimbFastPathMatchesGeneric)
     }
 }
 
+TEST(WideIntegerDivision, FourLimbFastPathMatchesGeneric)
+{
+    using U256 = gint::integer<256, unsigned>;
+
+    auto make_u256 = [](uint64_t w3, uint64_t w2, uint64_t w1, uint64_t w0)
+    {
+        U256 x = U256(w0);
+        x |= (U256(w1) << 64);
+        x |= (U256(w2) << 128);
+        x |= (U256(w3) << 192);
+        return x;
+    };
+
+    struct Case
+    {
+        U256 lhs;
+        U256 divisor;
+    };
+
+    Case cases[] = {
+        {make_u256(0xffffffffffffffffULL, 0xfffffffffffffffeULL, 0x0123456789abcdefULL, 0xfedcba9876543210ULL),
+         make_u256(0x8000000000000000ULL, 0x76543210fedcba98ULL, 0x89abcdef01234567ULL, 0x1111111111111111ULL)},
+        {make_u256(0x7fffffffffffffffULL, 0xffffffffffffffffULL, 0xffffffffffffffffULL, 0xfffffffffffffffeULL),
+         make_u256(0x0100000000000000ULL, 0x0000000000000001ULL, 0x0000000000000002ULL, 0x0000000000000003ULL)},
+        {make_u256(0x123456789abcdef0ULL, 0x0fedcba987654321ULL, 0x5555555555555555ULL, 0xaaaaaaaaaaaaaaaaULL),
+         make_u256(0xf000000000000000ULL, 0x0000000000000000ULL, 0x1111111111111111ULL, 0x2222222222222222ULL)},
+        {make_u256(0x9509d6071a3fb370ULL, 0x3fe7309369c26afaULL, 0xaa5e4674e9382781ULL, 0x8dde152b630710d3ULL),
+         make_u256(0x4a84eb038d1fd9b8ULL, 0x1ff39849b4e1357dULL, 0x552f233a8c25166aULL, 0xec188efbd080e66eULL)},
+        {make_u256(0x03e8fffffffffff0ULL, 0xbdc0000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL),
+         make_u256(0x0000ffffffffffffULL, 0xfc18ffffffffffffULL, 0xffff000000000000ULL, 0x0000000000000000ULL)},
+        {make_u256(0xfffffffffff4b97fULL, 0x2acaeb35c6adbe88ULL, 0x127d416f3e4cb89aULL, 0xd1a7d6787e53a11dULL),
+         make_u256(0x0000000000003e5eULL, 0x5c4882044378546aULL, 0xddae4b6cded24013ULL, 0x4aacad7bee6e9099ULL)},
+    };
+
+    for (const auto & c : cases)
+    {
+        U256 q_generic = TestAccess<U256>::div_large(c.lhs, c.divisor, 4);
+        U256 q_direct = TestAccess<U256>::div_large_4(c.lhs, c.divisor);
+        U256 q_fast = c.lhs / c.divisor;
+        U256 r_direct = c.lhs - q_direct * c.divisor;
+        U256 r_fast = c.lhs % c.divisor;
+
+        EXPECT_EQ(q_direct, q_generic);
+        EXPECT_EQ(q_fast, q_generic);
+        EXPECT_EQ(r_fast, r_direct);
+        EXPECT_LT(r_direct, c.divisor);
+    }
+}
+
 TEST(WideIntegerDivision, DivModSmallDivisorOne)
 {
     using U256 = gint::integer<256, unsigned>;


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：重点优化 `Div/SimilarMagnitude2`，同时覆盖 `Div/SimilarMagnitude` 与 `Mod/SimilarMagnitude` 的 256 位满宽除数路径。
- 环境：本机 AppleClang 21.0.0；Docker/GCC `gint:centos8`，GCC 8.5.0。

## 结果

- 新增 `div_large_4`，用于 `Int256` 满宽 4-limb 除数且商为单 limb 的除法路径；GCC-tuned 多 limb `%` 路径复用同一 quotient fast path。
- `Div/SimilarMagnitude2`：本机约 `15.061 ns -> 9.927 ns`，Docker/GCC 约 `19.689 ns -> 12.596 ns`。
- 非目标疑似慢项已用 `--benchmark_min_time=0.5s --benchmark_repetitions=5` 复核，未确认存在实际回退。
- 文档性能样本已按当前完整矩阵刷新。

## 验证

- `make test`：357/357 passed
- `docker run --rm -t -v "$PWD":/work -w /work gint:centos8 make TEST_BUILD_DIR=runs/docker/build-test test`：357/357 passed
- `make coverage`：`include/gint/gint.h` 行覆盖 98.1%，`div_large_4` 本体无未覆盖行
- Docker/GCC coverage：`include/gint/gint.h` 行覆盖 98.7%，`div_large_4` 本体和 GCC `%` dispatch 均命中
- 完整矩阵结果：`runs/local/compare_full_after_divlarge4_docs_20260426.json`、`runs/docker/compare_full_after_divlarge4_docs_20260426.json`

## 风险

- 变更限定在 256 位满宽除数的专用路径；其它宽度仍走既有 generic/stub 路径。
- Docker/GCC 编译仍会在既有 generic `div_large` 处输出 `-Waggressive-loop-optimizations` warning，本次未改动该 warning 来源。