### PR TITLE
fix: restore tuned fastpath coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,21 @@ if(GINT_BUILD_TESTS)
         DISCOVERY_TIMEOUT 60
     )
 
+    add_executable(gint_tests_gcc_tuned_fastpaths tests/gcc_tuned_fastpaths_test.cpp)
+    target_include_directories(gint_tests_gcc_tuned_fastpaths PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    set_target_properties(gint_tests_gcc_tuned_fastpaths PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
+    target_compile_options(gint_tests_gcc_tuned_fastpaths PRIVATE ${GINT_TEST_OPTIONS})
+    target_compile_definitions(gint_tests_gcc_tuned_fastpaths PRIVATE GINT_GCC_TUNED_PATHS=1 GINT_CLANG_TUNED_PATHS=0)
+    if(GINT_TEST_LINK_OPTIONS)
+        target_link_options(gint_tests_gcc_tuned_fastpaths PRIVATE ${GINT_TEST_LINK_OPTIONS})
+    endif()
+    target_link_libraries(gint_tests_gcc_tuned_fastpaths PRIVATE GTest::gtest_main)
+    gtest_discover_tests(gint_tests_gcc_tuned_fastpaths
+        TEST_PREFIX gcc_tuned_fastpaths.
+        NO_PRETTY_VALUES
+        DISCOVERY_TIMEOUT 60
+    )
+
     add_executable(gint_tests_divzero_checks tests/exceptions_overflow_test.cpp)
     target_include_directories(gint_tests_divzero_checks PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
     set_target_properties(gint_tests_divzero_checks PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -999,12 +999,6 @@ public:
             {
                 switch (limb_shift)
                 {
-                    case 0:
-                        out0 = src0;
-                        out1 = src1;
-                        out2 = src2;
-                        out3 = src3;
-                        break;
                     case 1:
                         out1 = src0;
                         out2 = src1;
@@ -1110,12 +1104,6 @@ public:
             {
                 switch (limb_shift)
                 {
-                    case 0:
-                        out0 = src0;
-                        out1 = src1;
-                        out2 = src2;
-                        out3 = src3;
-                        break;
                     case 1:
                         out0 = src1;
                         out1 = src2;
@@ -1604,7 +1592,7 @@ public:
             throw std::domain_error("infinite dividend");
         GINT_DIVZERO_CHECK(rhs.is_zero());
         return integer(lhs) / rhs;
-    }
+    } // LCOV_EXCL_LINE
 
     template <typename T, typename std::enable_if<detail::is_integral<T>::value, int>::type = 0>
     friend integer operator%(integer lhs, T rhs)
@@ -1651,7 +1639,7 @@ public:
         if (std::isinf(lhs))
             throw std::domain_error("infinite dividend in modulo");
         return integer(lhs) % rhs;
-    }
+    } // LCOV_EXCL_LINE
 
     friend constexpr bool operator==(const integer & lhs, const integer & rhs) noexcept
     {
@@ -2403,7 +2391,7 @@ private:
         if (lhs_neg != rhs_neg)
             negate_for_division(result);
         return result;
-    }
+    } // LCOV_EXCL_LINE
 
     static size_t used_limbs(const integer & v) noexcept
     {
@@ -3315,7 +3303,7 @@ template <size_t Bits, typename Signed>
 inline std::ostream & operator<<(std::ostream & out, const integer<Bits, Signed> & value)
 {
     return out << to_string(value);
-}
+} // LCOV_EXCL_LINE
 
 } // namespace gint
 
@@ -3335,7 +3323,7 @@ struct formatter<gint::integer<Bits, Signed>>
     auto format(const gint::integer<Bits, Signed> & value, FormatContext & ctx) const -> typename FormatContext::iterator
     {
         return fmt::format_to(ctx.out(), "{}", gint::to_string(value));
-    }
+    } // LCOV_EXCL_LINE
 };
 } // namespace fmt
 #endif

--- a/tests/gcc_tuned_fastpaths_test.cpp
+++ b/tests/gcc_tuned_fastpaths_test.cpp
@@ -1,0 +1,39 @@
+#include <gint/gint.h>
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using U256 = gint::integer<256, unsigned>;
+
+U256 make_u256(uint64_t w3, uint64_t w2, uint64_t w1, uint64_t w0)
+{
+    U256 x = U256(w0);
+    x |= U256(w1) << 64;
+    x |= U256(w2) << 128;
+    x |= U256(w3) << 192;
+    return x;
+}
+
+} // namespace
+
+TEST(GccTunedFastpaths, UInt256LowLimbMultiply)
+{
+    const uint64_t lhs64 = 0x123456789abcdef0ULL;
+    const uint64_t rhs64 = 0x10fedcba98765432ULL;
+
+    const U256 product = U256(lhs64) * U256(rhs64);
+    const unsigned __int128 expected = static_cast<unsigned __int128>(lhs64) * rhs64;
+
+    EXPECT_EQ(product, U256(expected));
+}
+
+TEST(GccTunedFastpaths, UInt256FullWidthModulo)
+{
+    const U256 divisor = make_u256(0x1000000000000000ULL, 0x0fedcba987654321ULL, 0x0123456789abcdefULL, 0x1111111111111111ULL);
+    const U256 remainder = 123456789ULL;
+    const U256 lhs = divisor * U256(9) + remainder;
+
+    EXPECT_EQ(lhs / divisor, U256(9));
+    EXPECT_EQ(lhs % divisor, remainder);
+}

--- a/tests/shift_test.cpp
+++ b/tests/shift_test.cpp
@@ -100,6 +100,23 @@ TEST(WideIntegerShift, ExactBoundaryBitCounts)
     EXPECT_EQ(minus_one >> 128, S128(-1));
 }
 
+TEST(WideIntegerShift, UInt256ExactWholeLimbRightShifts)
+{
+    using U256 = gint::integer<256, unsigned>;
+
+    U256 value = U256(0x1111111111111111ULL);
+    value |= U256(0x2222222222222222ULL) << 64;
+    value |= U256(0x3333333333333333ULL) << 128;
+    value |= U256(0x4444444444444444ULL) << 192;
+
+    U256 by64 = U256(0x2222222222222222ULL);
+    by64 |= U256(0x3333333333333333ULL) << 64;
+    by64 |= U256(0x4444444444444444ULL) << 128;
+    EXPECT_EQ(value >> 64, by64);
+
+    EXPECT_EQ(value >> 192, U256(0x4444444444444444ULL));
+}
+
 TEST(WideIntegerShift, SignedRightShiftWrapper)
 {
     using S128 = gint::integer<128, signed>;


### PR DESCRIPTION
## 问题

- 现象：最新 `main` 合入 256-bit full-width division / tuned fast path 后，`make coverage` 在 AppleClang/lcov 下回落到 98.1%，Docker/GCC lcov 回落到 98.7%。
- 根因：部分 `GINT_GCC_TUNED_PATHS` 路径在 AppleClang 默认配置下不会被普通测试目标实例化；4-limb exact whole-limb shift 中还保留了不可达的 `case 0`；AppleClang/lcov 对少量模板函数 closing brace 仍会产生行覆盖噪声。

## 修复

- 新增 `gint_tests_gcc_tuned_fastpaths`，显式以 `GINT_GCC_TUNED_PATHS=1` 覆盖 GCC-tuned multiply/modulo 路径。
- 补充 U256 exact whole-limb right shift 测试。
- 移除 4-limb exact shift 中不可达的 `case 0` 分支。
- 对已确认不是业务逻辑缺口的模板/function closing brace 使用 `LCOV_EXCL_LINE`。

## 验证

- `make test`：361/361 passed
- AppleClang/lcov `make coverage`：100.0% (1680/1680)
- Docker/GCC `make COVERAGE_DIR=runs/docker/build-coverage coverage`：100.0% (1487/1487)
- `git diff --check`：通过

## 风险

- 仅影响测试覆盖目标和覆盖率统计；运行时逻辑变化限于移除不可达分支。