### PR TITLE
refactor: 统一 CI 产物路径

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,16 +45,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ccache-
       - name: Configure
-        run: cmake -S . -B build -DGINT_BUILD_TESTS=ON -DGINT_BUILD_BENCHMARKS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        run: cmake -S . -B runs/ci/build -DGINT_BUILD_TESTS=ON -DGINT_BUILD_BENCHMARKS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build
-        run: cmake --build build --config Debug --parallel
+        run: cmake --build runs/ci/build --config Debug --parallel
       - name: Run tests
-        run: |
-          cd build
-          ctest -j 2 --output-on-failure
+        run: ctest --test-dir runs/ci/build -j 2 --output-on-failure
       - name: Header warning smoke
         run: |
-          cat > /tmp/gint_header_warning_smoke.cpp <<'CPP'
+          mkdir -p runs/ci
+          cat > runs/ci/gint_header_warning_smoke.cpp <<'CPP'
           #include <gint/gint.h>
           int main() {
               gint::integer<256, unsigned> x = 1;
@@ -62,7 +61,7 @@ jobs:
               return static_cast<int>(static_cast<unsigned long long>(y));
           }
           CPP
-          c++ -std=c++11 -Wall -Wextra -Werror -Iinclude /tmp/gint_header_warning_smoke.cpp -c -o /tmp/gint_header_warning_smoke.o
+          c++ -std=c++11 -Wall -Wextra -Werror -Iinclude runs/ci/gint_header_warning_smoke.cpp -c -o runs/ci/gint_header_warning_smoke.o
 
   build-cxx17:
     name: build (ubuntu-latest-cxx17)
@@ -83,11 +82,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ccache-
       - name: Configure
-        run: cmake -S . -B build -DGINT_BUILD_TESTS=ON -DGINT_BUILD_TESTS_CXX17=ON -DGINT_BUILD_BENCHMARKS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        run: cmake -S . -B runs/ci/build-cxx17 -DGINT_BUILD_TESTS=ON -DGINT_BUILD_TESTS_CXX17=ON -DGINT_BUILD_BENCHMARKS=OFF -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Build C++17 tests
-        run: cmake --build build --target gint_tests_cxx17 --config Debug --parallel
+        run: cmake --build runs/ci/build-cxx17 --target gint_tests_cxx17 --config Debug --parallel
       - name: Run C++17 tests
-        run: ./build/gint_tests_cxx17 --gtest_color=yes
+        run: ./runs/ci/build-cxx17/gint_tests_cxx17 --gtest_color=yes
 
   coverage:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 project(gint LANGUAGES CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)


### PR DESCRIPTION
## 概述

- 将 CI 普通构建与 C++17 构建目录统一到 `runs/ci/` 下。
- 将 header warning smoke 的临时源码和目标文件从 `/tmp` 移到 `runs/ci/`。
- 将 CMake 最低版本提升到 `3.13`，与 `target_link_options` 的实际要求一致。

## 行为不变性

- 不修改库代码、测试代码或 benchmark 逻辑。
- 仅调整 CI/构建产物目录和 CMake 版本声明。

## 验证

- CI 普通构建路径本地验证通过，`ctest`：361/361 passed。
- C++17 专用测试目标本地验证通过：169/169 passed。
- C++11 header warning smoke 通过。
- `git diff --check` 通过。

## 风险

- 低风险；主要影响 GitHub Actions 产物落点。`runs/` 已被 `.gitignore` 忽略。