### PR TITLE
perf: speed up x86 GCC full-width modulo

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -2947,6 +2947,11 @@ private:
             return result;
         }
 
+#if GINT_X86_64_GCC_TUNED_PATHS
+        if (limbs == 4 && divisor_limbs == 4)
+            return rem_large_4(lhs, divisor);
+#endif
+
         integer quotient;
         if (limbs == 2)
             quotient = div_128(lhs, divisor);
@@ -3246,11 +3251,137 @@ private:
         return quotient;
     }
 
+    template <size_t L = limbs>
+    static typename std::enable_if<(L == 4), integer>::type rem_large_4(integer lhs, const integer & divisor) noexcept
+    {
+        using u128 = unsigned __int128;
+
+        const int shift = __builtin_clzll(divisor.data_[3]);
+        limb_type u0;
+        limb_type u1;
+        limb_type u2;
+        limb_type u3;
+        limb_type u4;
+        limb_type v0;
+        limb_type v1;
+        limb_type v2;
+        limb_type v3;
+
+        if (shift == 0)
+        {
+            u0 = lhs.data_[0];
+            u1 = lhs.data_[1];
+            u2 = lhs.data_[2];
+            u3 = lhs.data_[3];
+            u4 = 0;
+            v0 = divisor.data_[0];
+            v1 = divisor.data_[1];
+            v2 = divisor.data_[2];
+            v3 = divisor.data_[3];
+        }
+        else
+        {
+            const int inv_shift = 64 - shift;
+            u0 = lhs.data_[0] << shift;
+            u1 = (lhs.data_[1] << shift) | (lhs.data_[0] >> inv_shift);
+            u2 = (lhs.data_[2] << shift) | (lhs.data_[1] >> inv_shift);
+            u3 = (lhs.data_[3] << shift) | (lhs.data_[2] >> inv_shift);
+            u4 = lhs.data_[3] >> inv_shift;
+            v0 = divisor.data_[0] << shift;
+            v1 = (divisor.data_[1] << shift) | (divisor.data_[0] >> inv_shift);
+            v2 = (divisor.data_[2] << shift) | (divisor.data_[1] >> inv_shift);
+            v3 = (divisor.data_[3] << shift) | (divisor.data_[2] >> inv_shift);
+        }
+
+        const u128 numerator = (static_cast<u128>(u4) << 64) | u3;
+        u128 qhat = numerator / v3;
+        u128 rhat = numerator - qhat * v3;
+
+        while (qhat == (static_cast<u128>(1) << 64) || qhat * v2 > ((rhat << 64) | u2))
+        {
+            --qhat;
+            rhat += v3;
+            if (rhat >= (static_cast<u128>(1) << 64))
+                break;
+        }
+
+        u128 borrow = 0;
+        {
+            u128 p = qhat * v0 + borrow;
+            const limb_type p_low = static_cast<limb_type>(p);
+            u0 = static_cast<limb_type>(static_cast<u128>(u0) - p);
+            borrow = (p >> 64) + (u0 > ~p_low);
+        }
+        {
+            u128 p = qhat * v1 + borrow;
+            const limb_type p_low = static_cast<limb_type>(p);
+            u1 = static_cast<limb_type>(static_cast<u128>(u1) - p);
+            borrow = (p >> 64) + (u1 > ~p_low);
+        }
+        {
+            u128 p = qhat * v2 + borrow;
+            const limb_type p_low = static_cast<limb_type>(p);
+            u2 = static_cast<limb_type>(static_cast<u128>(u2) - p);
+            borrow = (p >> 64) + (u2 > ~p_low);
+        }
+        {
+            u128 p = qhat * v3 + borrow;
+            const limb_type p_low = static_cast<limb_type>(p);
+            u3 = static_cast<limb_type>(static_cast<u128>(u3) - p);
+            borrow = (p >> 64) + (u3 > ~p_low);
+        }
+
+        if (static_cast<u128>(u4) < borrow)
+        {
+            u128 carry = 0;
+            u128 t = static_cast<u128>(u0) + v0 + carry;
+            u0 = static_cast<limb_type>(t);
+            carry = t >> 64;
+            t = static_cast<u128>(u1) + v1 + carry;
+            u1 = static_cast<limb_type>(t);
+            carry = t >> 64;
+            t = static_cast<u128>(u2) + v2 + carry;
+            u2 = static_cast<limb_type>(t);
+            carry = t >> 64;
+            t = static_cast<u128>(u3) + v3 + carry;
+            u3 = static_cast<limb_type>(t);
+            u4 = static_cast<limb_type>(static_cast<u128>(u4) + (t >> 64));
+        }
+        else
+        {
+            u4 = static_cast<limb_type>(static_cast<u128>(u4) - borrow);
+        }
+
+        integer result(uninitialized_tag{});
+        if (shift == 0)
+        {
+            result.data_[0] = u0;
+            result.data_[1] = u1;
+            result.data_[2] = u2;
+            result.data_[3] = u3;
+        }
+        else
+        {
+            const int inv_shift = 64 - shift;
+            result.data_[0] = (u0 >> shift) | (u1 << inv_shift);
+            result.data_[1] = (u1 >> shift) | (u2 << inv_shift);
+            result.data_[2] = (u2 >> shift) | (u3 << inv_shift);
+            result.data_[3] = (u3 >> shift) | (u4 << inv_shift);
+        }
+        return result;
+    }
+
     // Stub for non-256-bit instantiations to keep dependent calls well-formed.
     template <size_t L = limbs>
     static typename std::enable_if<(L != 4), integer>::type div_large_4(integer lhs, const integer & divisor) noexcept
     {
         return div_large(lhs, divisor, 4);
+    }
+
+    template <size_t L = limbs>
+    static typename std::enable_if<(L != 4), integer>::type rem_large_4(const integer & lhs, const integer &) noexcept
+    {
+        return lhs;
     }
 
     // Optimized specialization: two-limb divisor (divisor_limbs == 2)

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -3345,7 +3345,9 @@ private:
             carry = t >> 64;
             t = static_cast<u128>(u3) + v3 + carry;
             u3 = static_cast<limb_type>(t);
-            u4 = static_cast<limb_type>(static_cast<u128>(u4) + (t >> 64));
+            carry = t >> 64;
+            // The subtract phase has not yet applied this borrow to u4.
+            u4 = static_cast<limb_type>(static_cast<u128>(u4) + carry - borrow);
         }
         else
         {

--- a/tests/gcc_tuned_fastpaths_test.cpp
+++ b/tests/gcc_tuned_fastpaths_test.cpp
@@ -30,10 +30,30 @@ TEST(GccTunedFastpaths, UInt256LowLimbMultiply)
 
 TEST(GccTunedFastpaths, UInt256FullWidthModulo)
 {
-    const U256 divisor = make_u256(0x1000000000000000ULL, 0x0fedcba987654321ULL, 0x0123456789abcdefULL, 0x1111111111111111ULL);
-    const U256 remainder = 123456789ULL;
-    const U256 lhs = divisor * U256(9) + remainder;
+    struct Case
+    {
+        U256 divisor;
+        U256 quotient;
+        U256 remainder;
+    };
 
-    EXPECT_EQ(lhs / divisor, U256(9));
-    EXPECT_EQ(lhs % divisor, remainder);
+    const Case cases[] = {
+        {make_u256(0x1000000000000000ULL, 0x0fedcba987654321ULL, 0x0123456789abcdefULL, 0x1111111111111111ULL),
+         U256(9),
+         U256(123456789ULL)},
+        {make_u256(0x8000000000000000ULL, 0x76543210fedcba98ULL, 0x89abcdef01234567ULL, 0x1111111111111111ULL),
+         U256(1),
+         make_u256(0x0000000000000000ULL, 0x0000000000000001ULL, 0x2222222222222222ULL, 0x3333333333333333ULL)},
+        {make_u256(0x0000ffffffffffffULL, 0xfc18ffffffffffffULL, 0xffff000000000000ULL, 0x0000000000000001ULL),
+         U256(5),
+         make_u256(0x0000000000000000ULL, 0x0000000000000000ULL, 0x4444444444444444ULL, 0x5555555555555555ULL)},
+    };
+
+    for (const auto & c : cases)
+    {
+        const U256 lhs = c.divisor * c.quotient + c.remainder;
+
+        EXPECT_EQ(lhs / c.divisor, c.quotient);
+        EXPECT_EQ(lhs % c.divisor, c.remainder);
+    }
 }

--- a/tests/gcc_tuned_fastpaths_test.cpp
+++ b/tests/gcc_tuned_fastpaths_test.cpp
@@ -57,3 +57,13 @@ TEST(GccTunedFastpaths, UInt256FullWidthModulo)
         EXPECT_EQ(lhs % c.divisor, c.remainder);
     }
 }
+
+TEST(GccTunedFastpaths, UInt256FullWidthModuloAddBackBorrow)
+{
+    const U256 divisor = make_u256(0x000094db6cdc2e34ULL, 0xb91396c790d85d37ULL, 0xeb85403c7e8db475ULL, 0xd9621895e98f559dULL);
+    const U256 lhs = divisor - U256(0x40be4b66aaea7d9cULL);
+
+    EXPECT_LT(lhs, divisor);
+    EXPECT_EQ(lhs / divisor, U256(0));
+    EXPECT_EQ(lhs % divisor, lhs);
+}


### PR DESCRIPTION
Closes #93.

## 目标

- 用例 / 过滤器：`^Mod/SimilarMagnitude` 所在 issue93 关注矩阵，以及完整 `Int256` 对比矩阵。
- 环境：x86 GCC 针对路径；本机 AppleClang/arm64 用于确认非目标环境无整体回退。

## 做了什么

- 为 x86_64 GCC tuned path 增加 4-limb divisor 的直接 remainder 路径，避免 `%` 先求 quotient 再执行 `quotient * divisor` 和相减。
- 扩展 `gcc_tuned_fastpaths` 覆盖 4-limb modulo 的归一化与非归一化 divisor 场景。

## 结果

- x86 GCC `Mod/SimilarMagnitude/gint`：22.635ns -> 20.649ns，约 1.096x 加速。
- x86 GCC issue93 关注矩阵：8 项中 7 项快于最佳竞品，剩余 `Bitwise/And` 为亚纳秒级已知差距。
- 本机 AppleClang/arm64 完整矩阵：23 项中 21 胜 / 1 平 / 1 负，几何均值为最佳竞品的 0.508x。

结果文件：
- `runs/x86/gcc/issue93_continue_final_gcc.json`
- `runs/x86/gcc/candidate_rem4_gcc.json`
- `runs/local/overall_current_full_20260601.json`

## 验证

- `clang-format -i include/gint/gint.h tests/gcc_tuned_fastpaths_test.cpp`
- `git diff --check`
- `make TEST_BUILD_DIR=runs/local/build-test test`：361/361 passed
- 本机完整对比矩阵：`runs/local/overall_current_full_20260601.json`

## 风险

- 新路径仅在 `GINT_X86_64_GCC_TUNED_PATHS` 下启用，非 x86_64 GCC 环境继续使用原路径。
- 实现是固定 4-limb remainder 专用路径，风险集中在 qhat 修正与 add-back 分支；已通过新增 fastpath 测试覆盖典型 divisor 形态。