### PR TITLE
perf: consolidate wide mul and bitwise fastpaths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,28 +181,26 @@ if(GINT_BUILD_BENCHMARKS)
         endif()
     endif()
 
-    add_executable(perf_benchmark_int256
-        bench/benchmark_int256.cpp
-    )
-    set_target_properties(perf_benchmark_int256 PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-    target_include_directories(perf_benchmark_int256 PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party
-    )
-    target_compile_definitions(perf_benchmark_int256 PRIVATE GINT_ENABLE_FMT)
-    target_link_libraries(perf_benchmark_int256 PRIVATE fmt::fmt benchmark::benchmark)
-    target_compile_options(perf_benchmark_int256 PRIVATE ${GINT_BENCH_COMPILE_OPTIONS})
+    function(add_gint_bench_target target bits compare)
+        add_executable(${target}
+            bench/benchmark_int256.cpp
+        )
+        set_target_properties(${target} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
+        target_include_directories(${target} PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/third_party
+        )
+        target_compile_definitions(${target} PRIVATE GINT_ENABLE_FMT GINT_BENCH_BITS=${bits})
+        if(compare)
+            target_compile_definitions(${target} PRIVATE GINT_ENABLE_CH_COMPARE GINT_ENABLE_BOOST_COMPARE)
+        endif()
+        target_link_libraries(${target} PRIVATE fmt::fmt benchmark::benchmark)
+        target_compile_options(${target} PRIVATE ${GINT_BENCH_COMPILE_OPTIONS})
+    endfunction()
 
-    add_executable(perf_compare_int256
-        bench/benchmark_int256.cpp
-    )
-    set_target_properties(perf_compare_int256 PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-    target_include_directories(perf_compare_int256 PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party
-    )
-    target_compile_definitions(perf_compare_int256 PRIVATE GINT_ENABLE_FMT GINT_ENABLE_CH_COMPARE GINT_ENABLE_BOOST_COMPARE)
-    target_link_libraries(perf_compare_int256 PRIVATE fmt::fmt benchmark::benchmark)
-    target_compile_options(perf_compare_int256 PRIVATE ${GINT_BENCH_COMPILE_OPTIONS})
+    foreach(bits IN ITEMS 128 256 512 1024)
+        add_gint_bench_target(perf_benchmark_int${bits} ${bits} OFF)
+        add_gint_bench_target(perf_compare_int${bits} ${bits} ON)
+    endforeach()
 
 endif()

--- a/Makefile
+++ b/Makefile
@@ -42,27 +42,28 @@ test: $(TEST_BUILD_DIR)/Makefile
 
 # Build and run benchmarks
 BENCH_ARGS ?=
+BENCH_BITS ?= 256
 
 bench: $(BENCH_BUILD_DIR)/Makefile
-	cmake --build $(BENCH_BUILD_DIR) --parallel $(JOBS)
-	$(BENCH_BUILD_DIR)/perf_benchmark_int256 $(BENCH_ARGS)
+	cmake --build $(BENCH_BUILD_DIR) --target perf_benchmark_int$(BENCH_BITS) --parallel $(JOBS)
+	$(BENCH_BUILD_DIR)/perf_benchmark_int$(BENCH_BITS) $(BENCH_ARGS)
 
 # Build and run the full gint-only benchmark matrix
 bench-full: $(BENCH_BUILD_DIR)/Makefile
-	cmake --build $(BENCH_BUILD_DIR) --parallel $(JOBS)
+	cmake --build $(BENCH_BUILD_DIR) --target perf_benchmark_int$(BENCH_BITS) --parallel $(JOBS)
 	@echo "[full] Running gint-only full matrix ..."
-	$(BENCH_BUILD_DIR)/perf_benchmark_int256 --gint_full $(BENCH_ARGS)
+	$(BENCH_BUILD_DIR)/perf_benchmark_int$(BENCH_BITS) --gint_full $(BENCH_ARGS)
 
 # Build and run only the comparison benchmark
 bench-compare: $(BENCH_BUILD_DIR)/Makefile
-	cmake --build $(BENCH_BUILD_DIR) --target perf_compare_int256 --parallel $(JOBS)
-	$(BENCH_BUILD_DIR)/perf_compare_int256 $(BENCH_ARGS)
+	cmake --build $(BENCH_BUILD_DIR) --target perf_compare_int$(BENCH_BITS) --parallel $(JOBS)
+	$(BENCH_BUILD_DIR)/perf_compare_int$(BENCH_BITS) $(BENCH_ARGS)
 
 # Build and run the full comparison benchmark matrix
 bench-compare-full: $(BENCH_BUILD_DIR)/Makefile
-	cmake --build $(BENCH_BUILD_DIR) --parallel $(JOBS)
+	cmake --build $(BENCH_BUILD_DIR) --target perf_compare_int$(BENCH_BITS) --parallel $(JOBS)
 	@echo "[full] Running comparison full matrix ..."
-	$(BENCH_BUILD_DIR)/perf_compare_int256 --gint_full $(BENCH_ARGS)
+	$(BENCH_BUILD_DIR)/perf_compare_int$(BENCH_BITS) --gint_full $(BENCH_ARGS)
 
 # Build, test and generate coverage report (clean first to avoid stale data)
 coverage:

--- a/bench/benchmark_int256.cpp
+++ b/bench/benchmark_int256.cpp
@@ -14,12 +14,22 @@
 
 #include <gint/gint.h>
 
-using WInt = gint::integer<256, signed>;
+#ifndef GINT_BENCH_BITS
+#    define GINT_BENCH_BITS 256
+#endif
+
+constexpr size_t kBenchBits = GINT_BENCH_BITS;
+static_assert(kBenchBits % 64 == 0, "benchmark widths must be limb-aligned");
+static_assert(kBenchBits >= 128, "benchmark widths must be at least 128 bits");
+
+using WInt = gint::integer<kBenchBits, signed>;
 #ifdef GINT_ENABLE_CH_COMPARE
-using CInt = wide::integer<256, signed>;
+using CInt = wide::integer<kBenchBits, signed>;
 #endif
 #ifdef GINT_ENABLE_BOOST_COMPARE
-using BInt = boost::multiprecision::int256_t;
+using BInt = boost::multiprecision::number<
+    boost::multiprecision::
+        cpp_int_backend<kBenchBits, kBenchBits, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, void>>;
 #endif
 
 inline std::string to_string_convert(const WInt & x)
@@ -44,26 +54,36 @@ namespace
 
 constexpr size_t kDataN = 256; // small deterministic dataset per case
 constexpr uint64_t kSeedBase = 0x9E3779B97F4A7C15ull;
+constexpr size_t kBenchLimbs = kBenchBits / 64;
 
 template <typename Int>
-inline Int assemble_u256(uint64_t w0, uint64_t w1, uint64_t w2, uint64_t w3)
+inline Int assemble_words(const std::array<uint64_t, kBenchLimbs> & words)
 {
     Int x = Int{0};
-    x |= Int{w0};
-    x |= (Int{w1} << 64);
-    x |= (Int{w2} << 128);
-    x |= (Int{w3} << 192);
+    for (size_t i = 0; i < kBenchLimbs; ++i)
+        x |= (Int{words[i]} << static_cast<int>(i * 64));
     return x;
 }
 
 template <typename Int>
-inline Int random_u256_clear_msb(std::mt19937_64 & rng)
+inline Int random_wide(std::mt19937_64 & rng, bool clear_top_bit = false)
 {
-    uint64_t w0 = rng();
-    uint64_t w1 = rng();
-    uint64_t w2 = rng();
-    uint64_t w3 = rng() & 0x7FFF'FFFF'FFFF'FFFFull; // mask out the top bit to keep the value in a tighter range
-    return assemble_u256<Int>(w0, w1, w2, w3);
+    std::array<uint64_t, kBenchLimbs> words{};
+    for (size_t i = 0; i < kBenchLimbs; ++i)
+        words[i] = rng();
+    if (clear_top_bit)
+        words[kBenchLimbs - 1] &= 0x7FFF'FFFF'FFFF'FFFFull;
+    return assemble_words<Int>(words);
+}
+
+template <typename Int>
+inline Int random_wide_with_low_limb(std::mt19937_64 & rng, uint64_t low_limb)
+{
+    std::array<uint64_t, kBenchLimbs> words{};
+    words[0] = low_limb;
+    for (size_t i = 1; i < kBenchLimbs; ++i)
+        words[i] = rng();
+    return assemble_words<Int>(words);
 }
 
 } // namespace
@@ -78,12 +98,8 @@ static void Add_NoCarry(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xA55A'AA55'1234'5678ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            // a: random 256-bit; b: small 32-bit, avoids multi-limb carry in most cases
-            uint64_t w0 = rng();
-            uint64_t w1 = rng();
-            uint64_t w2 = rng();
-            uint64_t w3 = rng();
-            Int a = assemble_u256<Int>(w0, w1, w2, w3);
+            // a: random wide value; b: small 32-bit, avoids multi-limb carry in most cases
+            Int a = random_wide<Int>(rng);
             Int b = Int{uint32_t(rng())};
             d[i] = {a, b};
         }
@@ -101,7 +117,7 @@ static void Add_NoCarry(benchmark::State & state)
 }
 
 // -------- Mixed-operand: wide * u64 (compare) --------
-// Use fully random 256-bit 'a' to avoid accidentally benchmarking a degenerate one-limb case.
+// Use fully random wide 'a' to avoid accidentally benchmarking a degenerate one-limb case.
 template <typename Int>
 static void Mul_WideTimesU64(benchmark::State & state)
 {
@@ -111,8 +127,7 @@ static void Mul_WideTimesU64(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0x13579BDF'2468'ACE0ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            // assemble fully random 256-bit value
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             uint64_t b = rng();
             d[i] = {a, b};
         }
@@ -159,7 +174,7 @@ static void Sub_NoBorrow(benchmark::State & state)
         for (size_t i = 0; i < kDataN; ++i)
         {
             // a has low 32 bits set high (1<<31); b fits in 31 bits => no cross-limb borrow
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             a |= (Int{1} << 31);
             Int b = Int{uint32_t(rng() & 0x7FFF'FFFFu)};
             d[i] = {a, b};
@@ -230,8 +245,8 @@ static void Mul_HighxHigh(benchmark::State & state)
         for (size_t i = 0; i < kDataN; ++i)
         {
             // Set high words to trigger multi-limb schoolbook paths
-            Int a = (Int{1} << 200) | assemble_u256<Int>(rng(), rng(), rng(), 0);
-            Int b = (Int{1} << 180) | assemble_u256<Int>(rng(), rng(), rng(), 0);
+            Int a = (Int{1} << static_cast<int>(kBenchBits - 56)) | random_wide<Int>(rng);
+            Int b = (Int{1} << static_cast<int>(kBenchBits - 76)) | random_wide<Int>(rng);
             d[i] = {a, b};
         }
         return d;
@@ -257,7 +272,7 @@ static void Div_SmallDivisor32(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0x1234'5678'9ABC'DEF0ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             uint32_t dv = static_cast<uint32_t>((rng() | 1ull) & 0xFFFF'FFFFu); // ensure non-zero
             Int b = Int{dv};
             d[i] = {a, b};
@@ -285,7 +300,7 @@ static void Div_SmallDivisor64(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xA1B2'C3D4'E5F6'1234ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             uint64_t dv = (rng() | (1ull << 33)); // ensure > 2^33 and non-zero
             if ((dv & 0xFFFFFFFFULL) == dv)
                 dv |= (1ull << 40); // force out of 32-bit range
@@ -312,10 +327,10 @@ static void Div_Pow2Divisor(benchmark::State & state)
     {
         std::array<std::pair<Int, Int>, kDataN> d{};
         std::mt19937_64 rng(kSeedBase ^ 0xF00F'F00F'00F0'0F00ull);
-        std::uniform_int_distribution<int> dist_k(1, 200);
+        std::uniform_int_distribution<int> dist_k(1, static_cast<int>(kBenchBits - 56));
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             int k = dist_k(rng);
             Int b = (Int{1} << k);
             d[i] = {a, b};
@@ -340,10 +355,10 @@ static void Div_SimilarMagnitude(benchmark::State & state)
     {
         std::array<std::pair<Int, Int>, kDataN> d{};
         std::mt19937_64 rng(kSeedBase ^ 0x0BAD'CAFE'FEED'FACEull);
-        std::uniform_int_distribution<int> dist_shift(180, 220);
+        std::uniform_int_distribution<int> dist_shift(static_cast<int>(kBenchBits - 76), static_cast<int>(kBenchBits - 36));
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = (Int{1} << 255) - Int{uint32_t(rng())};
+            Int a = (Int{1} << static_cast<int>(kBenchBits - 1)) - Int{uint32_t(rng())};
             int s = dist_shift(rng);
             Int b = (Int{1} << s) + Int{uint32_t(rng())};
             d[i] = {a, b};
@@ -372,8 +387,8 @@ static void ToString(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xABCDEF123456ULL);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            // Generate numbers of different magnitudes (128-255 bits)
-            int shift = 128 + static_cast<int>(rng() % 128);
+            // Generate numbers of different magnitudes across the upper half of the configured width.
+            int shift = static_cast<int>(kBenchBits / 2 + (rng() % (kBenchBits / 2)));
             d[i] = (Int{1} << shift) + Int{rng()};
         }
         return d;
@@ -398,8 +413,8 @@ static void Bitwise_And(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xC0FFEE1234567890ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
-            Int b = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
+            Int b = random_wide<Int>(rng);
             d[i] = {a, b};
         }
         return d;
@@ -422,8 +437,8 @@ static void Bitwise_Xor(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xBAD5EEDBADC0FFEEull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
-            Int b = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
+            Int b = random_wide<Int>(rng);
             d[i] = {a, b};
         }
         return d;
@@ -445,10 +460,10 @@ static void Shift_LeftVariable(benchmark::State & state)
     {
         std::array<std::pair<Int, unsigned>, kDataN> d{};
         std::mt19937_64 rng(kSeedBase ^ 0x12345678ABCDEF01ull);
-        std::uniform_int_distribution<unsigned> dist(1, 255);
+        std::uniform_int_distribution<unsigned> dist(1, static_cast<unsigned>(kBenchBits - 1));
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             unsigned shift = dist(rng);
             d[i] = {a, shift};
         }
@@ -470,10 +485,10 @@ static void Shift_RightVariable(benchmark::State & state)
     {
         std::array<std::pair<Int, unsigned>, kDataN> d{};
         std::mt19937_64 rng(kSeedBase ^ 0x0FEDCBA987654321ull);
-        std::uniform_int_distribution<unsigned> dist(1, 255);
+        std::uniform_int_distribution<unsigned> dist(1, static_cast<unsigned>(kBenchBits - 1));
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             unsigned shift = dist(rng);
             d[i] = {a, shift};
         }
@@ -498,7 +513,7 @@ static void Mod_SmallDivisor64(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0x55AA3311CCDD8899ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = random_u256_clear_msb<Int>(rng);
+            Int a = random_wide<Int>(rng, true);
             uint64_t dv = rng() | (1ull << 32);
             dv |= 1ull; // keep it odd to avoid repeated powers of two
             Int b = Int{dv};
@@ -522,10 +537,10 @@ static void Mod_SimilarMagnitude(benchmark::State & state)
     {
         std::array<std::pair<Int, Int>, kDataN> d{};
         std::mt19937_64 rng(kSeedBase ^ 0x0F1E2D3C4B5A6978ull);
-        std::uniform_int_distribution<int> dist_shift(180, 220);
+        std::uniform_int_distribution<int> dist_shift(static_cast<int>(kBenchBits - 76), static_cast<int>(kBenchBits - 36));
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = (Int{1} << 255) - Int{uint32_t(rng())};
+            Int a = (Int{1} << static_cast<int>(kBenchBits - 1)) - Int{uint32_t(rng())};
             int s = dist_shift(rng);
             Int b = (Int{1} << s) + Int{uint32_t(rng())};
             if (b == Int{0})
@@ -595,7 +610,7 @@ static void Add_CarryChain64(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xCC55'DDAA'9988'7766ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(~0ULL, rng(), rng(), rng()); // low limb all 1s
+            Int a = random_wide_with_low_limb<Int>(rng, ~0ULL); // low limb all 1s
             Int b = Int{1};
             d[i] = {a, b};
         }
@@ -620,7 +635,7 @@ static void Sub_BorrowChain64(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0x1122'3344'5566'7788ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(0, rng(), rng(), rng()); // low limb zero
+            Int a = random_wide_with_low_limb<Int>(rng, 0); // low limb zero
             Int b = Int{1};
             d[i] = {a, b};
         }
@@ -645,7 +660,7 @@ static void Mul_U32xWide(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0x55AA'AA55'55AA'AA55ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             Int b = Int{static_cast<uint32_t>(rng())};
             d[i] = {a, b};
         }
@@ -672,7 +687,7 @@ static void Div_LargeDivisor128(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xD128ABCDEF01ULL);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = (Int{1} << 255) + Int{rng()};
+            Int a = (Int{1} << static_cast<int>(kBenchBits - 1)) + Int{rng()};
             Int b = (Int{1} << 127) + Int{rng() % 1000000};
             d[i] = {a, b};
         }
@@ -699,8 +714,8 @@ static void Div_SimilarMagnitude2(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xFEDCBA987654ULL);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = (Int{1} << 255) - Int{rng() % 10000000};
-            int s = 191 + static_cast<int>(rng() % 30); // 191-220
+            Int a = (Int{1} << static_cast<int>(kBenchBits - 1)) - Int{rng() % 10000000};
+            int s = static_cast<int>(kBenchBits - 65 + (rng() % 30));
             Int b = (Int{1} << s) + Int{rng() % 1000000000};
             d[i] = {a, b};
         }

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -24,6 +24,7 @@
 - 最短运行时间：建议加入 `--benchmark_min_time=0.2s`（单位必须为秒）。
 - 过滤子集：可用 `--benchmark_filter`（示例：`--benchmark_filter=^Div/SmallDivisor64/`）。
 - 完整矩阵：使用 `bench-full` 或 `bench-compare-full`，等价于给可执行传入 `--gint_full`。
+- 位宽选择：Makefile 默认 `BENCH_BITS=256`；可设为 `128/256/512/1024`，例如 `make BENCH_BITS=512 bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`。
 
 ## 基准测试（Benchmark）
 
@@ -35,6 +36,7 @@
 - 本机 AppleClang 完整矩阵：`make bench-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 - Docker/GCC 完整矩阵：`docker run --rm -t -v "$PWD":/work -w /work gint:centos8 make BENCH_BUILD_DIR=runs/docker/build-bench bench-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 - 本机直接运行：`runs/local/build-bench/perf_benchmark_int256 --benchmark_min_time=0.2s`
+- 其他位宽：`make BENCH_BITS=512 bench-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 
 ### 常用参数
 - `--benchmark_min_time=0.2s`：设置最短运行时间以降低抖动。
@@ -50,6 +52,7 @@
 - 本机 AppleClang 完整矩阵：`make bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 - Docker/GCC 完整矩阵：`docker run --rm -t -v "$PWD":/work -w /work gint:centos8 make BENCH_BUILD_DIR=runs/docker/build-bench bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 - 本机直接运行：`runs/local/build-bench/perf_compare_int256 --gint_full --benchmark_min_time=0.2s`
+- 其他位宽：`make BENCH_BITS=1024 bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 
 ### 方法学
 - 每个用例 256 对确定性样本（固定种子），循环中轮询；

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -168,6 +168,10 @@
 #    define GINT_ENABLE_X86_64_HW_SMALL_DIVMOD GINT_ARCH_X86_64
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH
+#    define GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#endif
+
 namespace gint
 {
 
@@ -719,6 +723,30 @@ bit_xor_limbs<4>(uint64_t * GINT_RESTRICT dst, const uint64_t * GINT_RESTRICT lh
     dst[2] = lhs[2] ^ rhs[2];
     dst[3] = lhs[3] ^ rhs[3];
 }
+
+#if GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH
+template <>
+GINT_CONSTEXPR14 GINT_FORCE_INLINE void
+bit_xor_limbs<16>(uint64_t * GINT_RESTRICT dst, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept
+{
+    dst[0] = lhs[0] ^ rhs[0];
+    dst[1] = lhs[1] ^ rhs[1];
+    dst[2] = lhs[2] ^ rhs[2];
+    dst[3] = lhs[3] ^ rhs[3];
+    dst[4] = lhs[4] ^ rhs[4];
+    dst[5] = lhs[5] ^ rhs[5];
+    dst[6] = lhs[6] ^ rhs[6];
+    dst[7] = lhs[7] ^ rhs[7];
+    dst[8] = lhs[8] ^ rhs[8];
+    dst[9] = lhs[9] ^ rhs[9];
+    dst[10] = lhs[10] ^ rhs[10];
+    dst[11] = lhs[11] ^ rhs[11];
+    dst[12] = lhs[12] ^ rhs[12];
+    dst[13] = lhs[13] ^ rhs[13];
+    dst[14] = lhs[14] ^ rhs[14];
+    dst[15] = lhs[15] ^ rhs[15];
+}
+#endif
 
 GINT_FORCE_INLINE void mul_limbs4_by_limb(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, uint64_t rhs) noexcept
 {
@@ -4040,3 +4068,4 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_ENABLE_POSITIVE_LIMB_DIV_FASTPATH
 #undef GINT_ENABLE_POSITIVE_LIMB_REM_FASTPATH
 #undef GINT_ENABLE_X86_64_HW_SMALL_DIVMOD
+#undef GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1114,6 +1114,17 @@ template <size_t L>
 GINT_NOINLINE bool
 mul_try_single_limb_operand(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept
 {
+    if (GINT_UNLIKELY((lhs[L - 1] | rhs[L - 1]) == 0))
+    {
+        uint64_t high_or = 0;
+        for (size_t i = 1; i < L; ++i)
+            high_or |= lhs[i] | rhs[i];
+        if (high_or == 0)
+        {
+            mul_single_limb_product<L>(res, lhs[0], rhs[0]);
+            return true;
+        }
+    }
     if (limbs_zero_above<L>(rhs, 1))
     {
         if (limbs_zero_above<L>(lhs, 1))

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -148,6 +148,10 @@
 #    define GINT_ENABLE_X86_64_GCC_MUL4_U64_FASTPATH (GINT_ARCH_X86_64 && GINT_GCC_TUNED_PATHS)
 #endif
 
+#ifndef GINT_ENABLE_WIDE_SINGLE_LIMB_MUL_FASTPATH
+#    define GINT_ENABLE_WIDE_SINGLE_LIMB_MUL_FASTPATH 1
+#endif
+
 #ifndef GINT_ENABLE_REM_QUOTIENT_MUL_FASTPATH
 #    define GINT_ENABLE_REM_QUOTIENT_MUL_FASTPATH GINT_GCC_TUNED_PATHS
 #endif
@@ -1040,9 +1044,17 @@ mul_limbs<4>(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, c
 }
 
 template <size_t L>
+GINT_NOINLINE bool
+mul_try_single_limb_operand(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept;
+
+template <size_t L>
 GINT_FORCE_INLINE void
 mul_limbs_result(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept
 {
+#if GINT_ENABLE_WIDE_SINGLE_LIMB_MUL_FASTPATH
+    if (L > 4 && GINT_UNLIKELY(lhs[L - 1] == 0 || rhs[L - 1] == 0) && mul_try_single_limb_operand<L>(res, lhs, rhs))
+        return;
+#endif
     for (size_t i = 0; i < L; ++i)
         res[i] = 0;
     mul_limbs<L>(res, lhs, rhs);
@@ -1060,6 +1072,62 @@ GINT_FORCE_INLINE void
 mul_limbs_result<4>(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept
 {
     mul_limbs<4>(res, lhs, rhs);
+}
+
+template <size_t L>
+GINT_FORCE_INLINE bool limbs_zero_above(const uint64_t * data, size_t first) noexcept
+{
+    if (data[L - 1] != 0)
+        return false;
+    for (size_t i = first; i < L; ++i)
+    {
+        if (data[i] != 0)
+            return false;
+    }
+    return true;
+}
+
+template <size_t L>
+GINT_FORCE_INLINE void mul_single_limb_product(uint64_t * res, uint64_t lhs, uint64_t rhs) noexcept
+{
+    const unsigned __int128 product = static_cast<unsigned __int128>(lhs) * rhs;
+    res[0] = static_cast<uint64_t>(product);
+    if (L > 1)
+        res[1] = static_cast<uint64_t>(product >> 64);
+    for (size_t i = 2; i < L; ++i)
+        res[i] = 0;
+}
+
+template <size_t L>
+GINT_FORCE_INLINE void mul_limbs_by_limb_result(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, uint64_t rhs) noexcept
+{
+    unsigned __int128 carry = 0;
+    for (size_t i = 0; i < L; ++i)
+    {
+        unsigned __int128 cur = static_cast<unsigned __int128>(lhs[i]) * rhs + carry;
+        res[i] = static_cast<uint64_t>(cur);
+        carry = cur >> 64;
+    }
+}
+
+template <size_t L>
+GINT_NOINLINE bool
+mul_try_single_limb_operand(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept
+{
+    if (limbs_zero_above<L>(rhs, 1))
+    {
+        if (limbs_zero_above<L>(lhs, 1))
+            mul_single_limb_product<L>(res, lhs[0], rhs[0]);
+        else
+            mul_limbs_by_limb_result<L>(res, lhs, rhs[0]);
+        return true;
+    }
+    if (limbs_zero_above<L>(lhs, 1))
+    {
+        mul_limbs_by_limb_result<L>(res, rhs, lhs[0]);
+        return true;
+    }
+    return false;
 }
 
 template <size_t L>
@@ -1745,9 +1813,9 @@ public:
     // Multiplication is left non-constexpr due to helper internals
     friend integer operator*(const integer & lhs, const integer & rhs) noexcept
     {
+        integer result(uninitialized_tag{});
         // Dispatch to the limb-wise multiplication routine which selects the
         // appropriate algorithm based on operand size.
-        integer result(uninitialized_tag{});
         detail::mul_limbs_result<limbs>(result.data_, lhs.data_, rhs.data_);
         return result;
     }

--- a/tests/arithmetic_mul_test.cpp
+++ b/tests/arithmetic_mul_test.cpp
@@ -119,6 +119,25 @@ TEST(WideIntegerMultiplication, UInt1024_WideTimesWide_Generic)
     EXPECT_EQ(prod, sum);
 }
 
+TEST(WideIntegerMultiplication, UInt1024_LowLimbOperands)
+{
+    using U1024 = gint::integer<1024, unsigned>;
+    const uint64_t lhs64 = 0x123456789abcdef0ULL;
+    const uint64_t rhs64 = 0x10fedcba98765432ULL;
+
+    const U1024 low_product = U1024(lhs64) * U1024(rhs64);
+    const unsigned __int128 expected = static_cast<unsigned __int128>(lhs64) * rhs64;
+    EXPECT_EQ(low_product, U1024(expected));
+
+    U1024 wide = 0;
+    wide += U1024(0x1122334455667788ULL);
+    wide += U1024(0x99aabbccddeeff00ULL) << 256;
+    wide += U1024(0x0102030405060708ULL) << 768;
+
+    const U1024 by_u32 = wide * U1024(7);
+    EXPECT_EQ(by_u32, wide + wide + wide + wide + wide + wide + wide);
+}
+
 // Multiplication by power-of-two equals left shift (wide×wide trigger)
 TEST(WideIntegerMultiplication, UInt256_MulByPow2EqualsShift)
 {


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`^Mul/(U64xU64|HighxHigh|WideTimesU64|U32xWide)`、`^Bitwise/(And|Xor)`
- 环境：本机 AppleClang/arm64 + Docker/GCC 8.5.0，`CMAKE_BUILD_TYPE=Release`

## 做了什么

- 合并宽位低 limb 乘法、1024-bit low-limb multiplication、aarch64 int1024 xor 的已验证优化。
- 保持快速路径在既有乘法/bitwise gate 内，不新增额外控制宏。

## 结果

- 完整分组矩阵中，512/1024 在本机 AppleClang 下目标项无明显落后；Docker/GCC 下 bitwise 仅剩 512/1024 与 ClickHouse 的几个百分点近似差距，不作为本轮继续拆分优化点。

## 验证

- 本机 AppleClang：379/379 tests passed
- Docker/GCC：379/379 tests passed
- 完整分组对比：int128/int256/int512/int1024，`--benchmark_min_time=0.2s --benchmark_repetitions=5`（本机）/ `3`（Docker）

## 风险

- bitwise 的剩余近似差距在 Docker/GCC 512/1024 上幅度很小，未继续增加专门快速路径。
