### PR TITLE
perf: speed up aarch64 int128 large divisor division

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,28 +181,26 @@ if(GINT_BUILD_BENCHMARKS)
         endif()
     endif()
 
-    add_executable(perf_benchmark_int256
-        bench/benchmark_int256.cpp
-    )
-    set_target_properties(perf_benchmark_int256 PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-    target_include_directories(perf_benchmark_int256 PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party
-    )
-    target_compile_definitions(perf_benchmark_int256 PRIVATE GINT_ENABLE_FMT)
-    target_link_libraries(perf_benchmark_int256 PRIVATE fmt::fmt benchmark::benchmark)
-    target_compile_options(perf_benchmark_int256 PRIVATE ${GINT_BENCH_COMPILE_OPTIONS})
+    function(add_gint_bench_target target bits compare)
+        add_executable(${target}
+            bench/benchmark_int256.cpp
+        )
+        set_target_properties(${target} PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
+        target_include_directories(${target} PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/third_party
+        )
+        target_compile_definitions(${target} PRIVATE GINT_ENABLE_FMT GINT_BENCH_BITS=${bits})
+        if(compare)
+            target_compile_definitions(${target} PRIVATE GINT_ENABLE_CH_COMPARE GINT_ENABLE_BOOST_COMPARE)
+        endif()
+        target_link_libraries(${target} PRIVATE fmt::fmt benchmark::benchmark)
+        target_compile_options(${target} PRIVATE ${GINT_BENCH_COMPILE_OPTIONS})
+    endfunction()
 
-    add_executable(perf_compare_int256
-        bench/benchmark_int256.cpp
-    )
-    set_target_properties(perf_compare_int256 PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
-    target_include_directories(perf_compare_int256 PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party
-    )
-    target_compile_definitions(perf_compare_int256 PRIVATE GINT_ENABLE_FMT GINT_ENABLE_CH_COMPARE GINT_ENABLE_BOOST_COMPARE)
-    target_link_libraries(perf_compare_int256 PRIVATE fmt::fmt benchmark::benchmark)
-    target_compile_options(perf_compare_int256 PRIVATE ${GINT_BENCH_COMPILE_OPTIONS})
+    foreach(bits IN ITEMS 128 256 512 1024)
+        add_gint_bench_target(perf_benchmark_int${bits} ${bits} OFF)
+        add_gint_bench_target(perf_compare_int${bits} ${bits} ON)
+    endforeach()
 
 endif()

--- a/Makefile
+++ b/Makefile
@@ -42,27 +42,28 @@ test: $(TEST_BUILD_DIR)/Makefile
 
 # Build and run benchmarks
 BENCH_ARGS ?=
+BENCH_BITS ?= 256
 
 bench: $(BENCH_BUILD_DIR)/Makefile
-	cmake --build $(BENCH_BUILD_DIR) --parallel $(JOBS)
-	$(BENCH_BUILD_DIR)/perf_benchmark_int256 $(BENCH_ARGS)
+	cmake --build $(BENCH_BUILD_DIR) --target perf_benchmark_int$(BENCH_BITS) --parallel $(JOBS)
+	$(BENCH_BUILD_DIR)/perf_benchmark_int$(BENCH_BITS) $(BENCH_ARGS)
 
 # Build and run the full gint-only benchmark matrix
 bench-full: $(BENCH_BUILD_DIR)/Makefile
-	cmake --build $(BENCH_BUILD_DIR) --parallel $(JOBS)
+	cmake --build $(BENCH_BUILD_DIR) --target perf_benchmark_int$(BENCH_BITS) --parallel $(JOBS)
 	@echo "[full] Running gint-only full matrix ..."
-	$(BENCH_BUILD_DIR)/perf_benchmark_int256 --gint_full $(BENCH_ARGS)
+	$(BENCH_BUILD_DIR)/perf_benchmark_int$(BENCH_BITS) --gint_full $(BENCH_ARGS)
 
 # Build and run only the comparison benchmark
 bench-compare: $(BENCH_BUILD_DIR)/Makefile
-	cmake --build $(BENCH_BUILD_DIR) --target perf_compare_int256 --parallel $(JOBS)
-	$(BENCH_BUILD_DIR)/perf_compare_int256 $(BENCH_ARGS)
+	cmake --build $(BENCH_BUILD_DIR) --target perf_compare_int$(BENCH_BITS) --parallel $(JOBS)
+	$(BENCH_BUILD_DIR)/perf_compare_int$(BENCH_BITS) $(BENCH_ARGS)
 
 # Build and run the full comparison benchmark matrix
 bench-compare-full: $(BENCH_BUILD_DIR)/Makefile
-	cmake --build $(BENCH_BUILD_DIR) --parallel $(JOBS)
+	cmake --build $(BENCH_BUILD_DIR) --target perf_compare_int$(BENCH_BITS) --parallel $(JOBS)
 	@echo "[full] Running comparison full matrix ..."
-	$(BENCH_BUILD_DIR)/perf_compare_int256 --gint_full $(BENCH_ARGS)
+	$(BENCH_BUILD_DIR)/perf_compare_int$(BENCH_BITS) --gint_full $(BENCH_ARGS)
 
 # Build, test and generate coverage report (clean first to avoid stale data)
 coverage:

--- a/bench/benchmark_int256.cpp
+++ b/bench/benchmark_int256.cpp
@@ -14,12 +14,22 @@
 
 #include <gint/gint.h>
 
-using WInt = gint::integer<256, signed>;
+#ifndef GINT_BENCH_BITS
+#    define GINT_BENCH_BITS 256
+#endif
+
+constexpr size_t kBenchBits = GINT_BENCH_BITS;
+static_assert(kBenchBits % 64 == 0, "benchmark widths must be limb-aligned");
+static_assert(kBenchBits >= 128, "benchmark widths must be at least 128 bits");
+
+using WInt = gint::integer<kBenchBits, signed>;
 #ifdef GINT_ENABLE_CH_COMPARE
-using CInt = wide::integer<256, signed>;
+using CInt = wide::integer<kBenchBits, signed>;
 #endif
 #ifdef GINT_ENABLE_BOOST_COMPARE
-using BInt = boost::multiprecision::int256_t;
+using BInt = boost::multiprecision::number<
+    boost::multiprecision::
+        cpp_int_backend<kBenchBits, kBenchBits, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, void>>;
 #endif
 
 inline std::string to_string_convert(const WInt & x)
@@ -44,26 +54,36 @@ namespace
 
 constexpr size_t kDataN = 256; // small deterministic dataset per case
 constexpr uint64_t kSeedBase = 0x9E3779B97F4A7C15ull;
+constexpr size_t kBenchLimbs = kBenchBits / 64;
 
 template <typename Int>
-inline Int assemble_u256(uint64_t w0, uint64_t w1, uint64_t w2, uint64_t w3)
+inline Int assemble_words(const std::array<uint64_t, kBenchLimbs> & words)
 {
     Int x = Int{0};
-    x |= Int{w0};
-    x |= (Int{w1} << 64);
-    x |= (Int{w2} << 128);
-    x |= (Int{w3} << 192);
+    for (size_t i = 0; i < kBenchLimbs; ++i)
+        x |= (Int{words[i]} << static_cast<int>(i * 64));
     return x;
 }
 
 template <typename Int>
-inline Int random_u256_clear_msb(std::mt19937_64 & rng)
+inline Int random_wide(std::mt19937_64 & rng, bool clear_top_bit = false)
 {
-    uint64_t w0 = rng();
-    uint64_t w1 = rng();
-    uint64_t w2 = rng();
-    uint64_t w3 = rng() & 0x7FFF'FFFF'FFFF'FFFFull; // mask out the top bit to keep the value in a tighter range
-    return assemble_u256<Int>(w0, w1, w2, w3);
+    std::array<uint64_t, kBenchLimbs> words{};
+    for (size_t i = 0; i < kBenchLimbs; ++i)
+        words[i] = rng();
+    if (clear_top_bit)
+        words[kBenchLimbs - 1] &= 0x7FFF'FFFF'FFFF'FFFFull;
+    return assemble_words<Int>(words);
+}
+
+template <typename Int>
+inline Int random_wide_with_low_limb(std::mt19937_64 & rng, uint64_t low_limb)
+{
+    std::array<uint64_t, kBenchLimbs> words{};
+    words[0] = low_limb;
+    for (size_t i = 1; i < kBenchLimbs; ++i)
+        words[i] = rng();
+    return assemble_words<Int>(words);
 }
 
 } // namespace
@@ -78,12 +98,8 @@ static void Add_NoCarry(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xA55A'AA55'1234'5678ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            // a: random 256-bit; b: small 32-bit, avoids multi-limb carry in most cases
-            uint64_t w0 = rng();
-            uint64_t w1 = rng();
-            uint64_t w2 = rng();
-            uint64_t w3 = rng();
-            Int a = assemble_u256<Int>(w0, w1, w2, w3);
+            // a: random wide value; b: small 32-bit, avoids multi-limb carry in most cases
+            Int a = random_wide<Int>(rng);
             Int b = Int{uint32_t(rng())};
             d[i] = {a, b};
         }
@@ -101,7 +117,7 @@ static void Add_NoCarry(benchmark::State & state)
 }
 
 // -------- Mixed-operand: wide * u64 (compare) --------
-// Use fully random 256-bit 'a' to avoid accidentally benchmarking a degenerate one-limb case.
+// Use fully random wide 'a' to avoid accidentally benchmarking a degenerate one-limb case.
 template <typename Int>
 static void Mul_WideTimesU64(benchmark::State & state)
 {
@@ -111,8 +127,7 @@ static void Mul_WideTimesU64(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0x13579BDF'2468'ACE0ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            // assemble fully random 256-bit value
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             uint64_t b = rng();
             d[i] = {a, b};
         }
@@ -159,7 +174,7 @@ static void Sub_NoBorrow(benchmark::State & state)
         for (size_t i = 0; i < kDataN; ++i)
         {
             // a has low 32 bits set high (1<<31); b fits in 31 bits => no cross-limb borrow
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             a |= (Int{1} << 31);
             Int b = Int{uint32_t(rng() & 0x7FFF'FFFFu)};
             d[i] = {a, b};
@@ -230,8 +245,8 @@ static void Mul_HighxHigh(benchmark::State & state)
         for (size_t i = 0; i < kDataN; ++i)
         {
             // Set high words to trigger multi-limb schoolbook paths
-            Int a = (Int{1} << 200) | assemble_u256<Int>(rng(), rng(), rng(), 0);
-            Int b = (Int{1} << 180) | assemble_u256<Int>(rng(), rng(), rng(), 0);
+            Int a = (Int{1} << static_cast<int>(kBenchBits - 56)) | random_wide<Int>(rng);
+            Int b = (Int{1} << static_cast<int>(kBenchBits - 76)) | random_wide<Int>(rng);
             d[i] = {a, b};
         }
         return d;
@@ -257,7 +272,7 @@ static void Div_SmallDivisor32(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0x1234'5678'9ABC'DEF0ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             uint32_t dv = static_cast<uint32_t>((rng() | 1ull) & 0xFFFF'FFFFu); // ensure non-zero
             Int b = Int{dv};
             d[i] = {a, b};
@@ -285,7 +300,7 @@ static void Div_SmallDivisor64(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xA1B2'C3D4'E5F6'1234ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             uint64_t dv = (rng() | (1ull << 33)); // ensure > 2^33 and non-zero
             if ((dv & 0xFFFFFFFFULL) == dv)
                 dv |= (1ull << 40); // force out of 32-bit range
@@ -312,10 +327,10 @@ static void Div_Pow2Divisor(benchmark::State & state)
     {
         std::array<std::pair<Int, Int>, kDataN> d{};
         std::mt19937_64 rng(kSeedBase ^ 0xF00F'F00F'00F0'0F00ull);
-        std::uniform_int_distribution<int> dist_k(1, 200);
+        std::uniform_int_distribution<int> dist_k(1, static_cast<int>(kBenchBits - 56));
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             int k = dist_k(rng);
             Int b = (Int{1} << k);
             d[i] = {a, b};
@@ -340,10 +355,10 @@ static void Div_SimilarMagnitude(benchmark::State & state)
     {
         std::array<std::pair<Int, Int>, kDataN> d{};
         std::mt19937_64 rng(kSeedBase ^ 0x0BAD'CAFE'FEED'FACEull);
-        std::uniform_int_distribution<int> dist_shift(180, 220);
+        std::uniform_int_distribution<int> dist_shift(static_cast<int>(kBenchBits - 76), static_cast<int>(kBenchBits - 36));
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = (Int{1} << 255) - Int{uint32_t(rng())};
+            Int a = (Int{1} << static_cast<int>(kBenchBits - 1)) - Int{uint32_t(rng())};
             int s = dist_shift(rng);
             Int b = (Int{1} << s) + Int{uint32_t(rng())};
             d[i] = {a, b};
@@ -372,8 +387,8 @@ static void ToString(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xABCDEF123456ULL);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            // Generate numbers of different magnitudes (128-255 bits)
-            int shift = 128 + static_cast<int>(rng() % 128);
+            // Generate numbers of different magnitudes across the upper half of the configured width.
+            int shift = static_cast<int>(kBenchBits / 2 + (rng() % (kBenchBits / 2)));
             d[i] = (Int{1} << shift) + Int{rng()};
         }
         return d;
@@ -398,8 +413,8 @@ static void Bitwise_And(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xC0FFEE1234567890ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
-            Int b = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
+            Int b = random_wide<Int>(rng);
             d[i] = {a, b};
         }
         return d;
@@ -422,8 +437,8 @@ static void Bitwise_Xor(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xBAD5EEDBADC0FFEEull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
-            Int b = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
+            Int b = random_wide<Int>(rng);
             d[i] = {a, b};
         }
         return d;
@@ -445,10 +460,10 @@ static void Shift_LeftVariable(benchmark::State & state)
     {
         std::array<std::pair<Int, unsigned>, kDataN> d{};
         std::mt19937_64 rng(kSeedBase ^ 0x12345678ABCDEF01ull);
-        std::uniform_int_distribution<unsigned> dist(1, 255);
+        std::uniform_int_distribution<unsigned> dist(1, static_cast<unsigned>(kBenchBits - 1));
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             unsigned shift = dist(rng);
             d[i] = {a, shift};
         }
@@ -470,10 +485,10 @@ static void Shift_RightVariable(benchmark::State & state)
     {
         std::array<std::pair<Int, unsigned>, kDataN> d{};
         std::mt19937_64 rng(kSeedBase ^ 0x0FEDCBA987654321ull);
-        std::uniform_int_distribution<unsigned> dist(1, 255);
+        std::uniform_int_distribution<unsigned> dist(1, static_cast<unsigned>(kBenchBits - 1));
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             unsigned shift = dist(rng);
             d[i] = {a, shift};
         }
@@ -498,7 +513,7 @@ static void Mod_SmallDivisor64(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0x55AA3311CCDD8899ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = random_u256_clear_msb<Int>(rng);
+            Int a = random_wide<Int>(rng, true);
             uint64_t dv = rng() | (1ull << 32);
             dv |= 1ull; // keep it odd to avoid repeated powers of two
             Int b = Int{dv};
@@ -522,10 +537,10 @@ static void Mod_SimilarMagnitude(benchmark::State & state)
     {
         std::array<std::pair<Int, Int>, kDataN> d{};
         std::mt19937_64 rng(kSeedBase ^ 0x0F1E2D3C4B5A6978ull);
-        std::uniform_int_distribution<int> dist_shift(180, 220);
+        std::uniform_int_distribution<int> dist_shift(static_cast<int>(kBenchBits - 76), static_cast<int>(kBenchBits - 36));
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = (Int{1} << 255) - Int{uint32_t(rng())};
+            Int a = (Int{1} << static_cast<int>(kBenchBits - 1)) - Int{uint32_t(rng())};
             int s = dist_shift(rng);
             Int b = (Int{1} << s) + Int{uint32_t(rng())};
             if (b == Int{0})
@@ -595,7 +610,7 @@ static void Add_CarryChain64(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xCC55'DDAA'9988'7766ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(~0ULL, rng(), rng(), rng()); // low limb all 1s
+            Int a = random_wide_with_low_limb<Int>(rng, ~0ULL); // low limb all 1s
             Int b = Int{1};
             d[i] = {a, b};
         }
@@ -620,7 +635,7 @@ static void Sub_BorrowChain64(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0x1122'3344'5566'7788ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(0, rng(), rng(), rng()); // low limb zero
+            Int a = random_wide_with_low_limb<Int>(rng, 0); // low limb zero
             Int b = Int{1};
             d[i] = {a, b};
         }
@@ -645,7 +660,7 @@ static void Mul_U32xWide(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0x55AA'AA55'55AA'AA55ull);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = assemble_u256<Int>(rng(), rng(), rng(), rng());
+            Int a = random_wide<Int>(rng);
             Int b = Int{static_cast<uint32_t>(rng())};
             d[i] = {a, b};
         }
@@ -672,7 +687,7 @@ static void Div_LargeDivisor128(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xD128ABCDEF01ULL);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = (Int{1} << 255) + Int{rng()};
+            Int a = (Int{1} << static_cast<int>(kBenchBits - 1)) + Int{rng()};
             Int b = (Int{1} << 127) + Int{rng() % 1000000};
             d[i] = {a, b};
         }
@@ -699,8 +714,8 @@ static void Div_SimilarMagnitude2(benchmark::State & state)
         std::mt19937_64 rng(kSeedBase ^ 0xFEDCBA987654ULL);
         for (size_t i = 0; i < kDataN; ++i)
         {
-            Int a = (Int{1} << 255) - Int{rng() % 10000000};
-            int s = 191 + static_cast<int>(rng() % 30); // 191-220
+            Int a = (Int{1} << static_cast<int>(kBenchBits - 1)) - Int{rng() % 10000000};
+            int s = static_cast<int>(kBenchBits - 65 + (rng() % 30));
             Int b = (Int{1} << s) + Int{rng() % 1000000000};
             d[i] = {a, b};
         }

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -24,6 +24,7 @@
 - 最短运行时间：建议加入 `--benchmark_min_time=0.2s`（单位必须为秒）。
 - 过滤子集：可用 `--benchmark_filter`（示例：`--benchmark_filter=^Div/SmallDivisor64/`）。
 - 完整矩阵：使用 `bench-full` 或 `bench-compare-full`，等价于给可执行传入 `--gint_full`。
+- 位宽选择：Makefile 默认 `BENCH_BITS=256`；可设为 `128/256/512/1024`，例如 `make BENCH_BITS=512 bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`。
 
 ## 基准测试（Benchmark）
 
@@ -35,6 +36,7 @@
 - 本机 AppleClang 完整矩阵：`make bench-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 - Docker/GCC 完整矩阵：`docker run --rm -t -v "$PWD":/work -w /work gint:centos8 make BENCH_BUILD_DIR=runs/docker/build-bench bench-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 - 本机直接运行：`runs/local/build-bench/perf_benchmark_int256 --benchmark_min_time=0.2s`
+- 其他位宽：`make BENCH_BITS=512 bench-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 
 ### 常用参数
 - `--benchmark_min_time=0.2s`：设置最短运行时间以降低抖动。
@@ -50,6 +52,7 @@
 - 本机 AppleClang 完整矩阵：`make bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 - Docker/GCC 完整矩阵：`docker run --rm -t -v "$PWD":/work -w /work gint:centos8 make BENCH_BUILD_DIR=runs/docker/build-bench bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 - 本机直接运行：`runs/local/build-bench/perf_compare_int256 --gint_full --benchmark_min_time=0.2s`
+- 其他位宽：`make BENCH_BITS=1024 bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 
 ### 方法学
 - 每个用例 256 对确定性样本（固定种子），循环中轮询；

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -168,6 +168,12 @@
 #    define GINT_ENABLE_X86_64_HW_SMALL_DIVMOD GINT_ARCH_X86_64
 #endif
 
+#if GINT_X86_64_GCC_TUNED_PATHS
+#    define GINT_WIDE_SHIFT_INLINE inline GINT_NOINLINE GINT_COLD
+#else
+#    define GINT_WIDE_SHIFT_INLINE GINT_FORCE_INLINE
+#endif
+
 namespace gint
 {
 
@@ -1452,24 +1458,28 @@ public:
             data_[3] = static_cast<limb_type>(out3);
             return *this;
         }
-        if (limb_shift)
+        if (limbs < 4)
         {
-            for (size_t i = limbs; i-- > limb_shift;)
-                data_[i] = data_[i - limb_shift];
-            for (size_t i = 0; i < limb_shift; ++i)
-                data_[i] = 0;
-        }
-        if (bit_shift)
-        {
-            for (size_t i = limbs; i-- > 0;)
+            if (limb_shift)
             {
-                unsigned __int128 part = static_cast<unsigned __int128>(data_[i]) << bit_shift;
-                if (i)
-                    part |= data_[i - 1] >> (64 - bit_shift);
-                data_[i] = static_cast<limb_type>(part);
+                for (size_t i = limbs; i-- > limb_shift;)
+                    data_[i] = data_[i - limb_shift];
+                for (size_t i = 0; i < limb_shift; ++i)
+                    data_[i] = 0;
             }
+            if (bit_shift)
+            {
+                for (size_t i = limbs; i-- > 0;)
+                {
+                    unsigned __int128 part = static_cast<unsigned __int128>(data_[i]) << bit_shift;
+                    if (i)
+                        part |= data_[i - 1] >> (64 - bit_shift);
+                    data_[i] = static_cast<limb_type>(part);
+                }
+            }
+            return *this;
         }
-        return *this;
+        return shift_left_assign_wide(limb_shift, static_cast<unsigned>(bit_shift));
     }
 
     GINT_CONSTEXPR14 GINT_FORCE_INLINE integer & operator>>=(int n) noexcept
@@ -1563,29 +1573,204 @@ public:
             data_[3] = static_cast<limb_type>(out3);
             return *this;
         }
-        if (limb_shift)
+        if (limbs < 4)
         {
-            for (size_t i = 0; i < limbs - limb_shift; ++i)
-                data_[i] = data_[i + limb_shift];
-            for (size_t i = limbs - limb_shift; i < limbs; ++i)
-                data_[i] = fill;
+            if (limb_shift)
+            {
+                for (size_t i = 0; i < limbs - limb_shift; ++i)
+                    data_[i] = data_[i + limb_shift];
+                for (size_t i = limbs - limb_shift; i < limbs; ++i)
+                    data_[i] = fill;
+            }
+            if (bit_shift)
+            {
+                const unsigned inv_shift = 64U - bit_shift;
+                const limb_type top = data_[limbs - 1];
+                limb_type prev = top;
+                for (size_t i = limbs - 1; i > 0; --i)
+                {
+                    limb_type cur = data_[i - 1];
+                    data_[i - 1] = (cur >> bit_shift) | (prev << inv_shift);
+                    prev = cur;
+                }
+                data_[limbs - 1] = (top >> bit_shift) | (fill << inv_shift);
+            }
+            return *this;
         }
+        return shift_right_assign_wide(limb_shift, bit_shift, fill);
+    }
+
+private:
+    GINT_CONSTEXPR14 GINT_WIDE_SHIFT_INLINE integer & shift_left_assign_wide(size_t limb_shift, unsigned bit_shift) noexcept
+    {
         if (bit_shift)
         {
-            const unsigned inv_shift = 64U - bit_shift;
-            const limb_type top = data_[limbs - 1];
-            limb_type prev = top;
-            for (size_t i = limbs - 1; i > 0; --i)
+            const unsigned shift_bits = static_cast<unsigned>(bit_shift);
+            const unsigned inv_shift = 64U - shift_bits;
+            for (size_t i = limbs; i-- > 0;)
             {
-                limb_type cur = data_[i - 1];
-                data_[i - 1] = (cur >> bit_shift) | (prev << inv_shift);
-                prev = cur;
+                if (i < limb_shift)
+                {
+                    data_[i] = 0;
+                    continue;
+                }
+
+                const size_t src = i - limb_shift;
+                limb_type part = data_[src] << shift_bits;
+                if (src)
+                    part |= data_[src - 1] >> inv_shift;
+                data_[i] = part;
             }
-            data_[limbs - 1] = (top >> bit_shift) | (fill << inv_shift);
+        }
+        else if (limb_shift)
+        {
+            for (size_t i = limbs; i-- > limb_shift;)
+                data_[i] = data_[i - limb_shift];
+            for (size_t i = 0; i < limb_shift; ++i)
+                data_[i] = 0;
         }
         return *this;
     }
 
+    GINT_CONSTEXPR14 GINT_WIDE_SHIFT_INLINE integer &
+    shift_right_assign_wide(size_t limb_shift, unsigned bit_shift, limb_type fill) noexcept
+    {
+        if (bit_shift)
+        {
+            const unsigned inv_shift = 64U - bit_shift;
+            const size_t count = limbs - limb_shift;
+            for (size_t i = 0; i < count; ++i)
+            {
+                const size_t src = i + limb_shift;
+                limb_type part = data_[src] >> bit_shift;
+                if (src + 1 < limbs)
+                    part |= data_[src + 1] << inv_shift;
+                else
+                    part |= fill << inv_shift;
+                data_[i] = part;
+            }
+            for (size_t i = count; i < limbs; ++i)
+                data_[i] = fill;
+        }
+        else if (limb_shift)
+        {
+            const size_t count = limbs - limb_shift;
+            for (size_t i = 0; i < count; ++i)
+                data_[i] = data_[i + limb_shift];
+            for (size_t i = count; i < limbs; ++i)
+                data_[i] = fill;
+        }
+        return *this;
+    }
+
+#if !GINT_GCC_TUNED_PATHS
+    static GINT_CONSTEXPR14 GINT_FORCE_INLINE integer shift_left_value(const integer & value, int n) noexcept
+    {
+        if (limbs == 4)
+        {
+            integer result = value;
+            result <<= n;
+            return result;
+        }
+        if (n <= 0)
+            return value;
+
+        const size_t total_bits = limbs * 64;
+        const size_t shift = static_cast<size_t>(n);
+#    if __cplusplus >= 201402L
+        integer result;
+#    else
+        integer result(uninitialized_tag{});
+#    endif
+        if (shift >= total_bits)
+        {
+            for (size_t i = 0; i < limbs; ++i)
+                result.data_[i] = 0;
+            return result;
+        }
+
+        const size_t limb_shift = shift / 64;
+        const unsigned bit_shift = static_cast<unsigned>(shift % 64);
+        if (bit_shift)
+        {
+            const unsigned inv_shift = 64U - bit_shift;
+            for (size_t i = 0; i < limb_shift; ++i)
+                result.data_[i] = 0;
+
+            const size_t count = limbs - limb_shift;
+            limb_type carry = 0;
+            for (size_t i = 0; i < count; ++i)
+            {
+                const limb_type cur = value.data_[i];
+                result.data_[i + limb_shift] = (cur << bit_shift) | carry;
+                carry = cur >> inv_shift;
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < limb_shift; ++i)
+                result.data_[i] = 0;
+            for (size_t i = limb_shift; i < limbs; ++i)
+                result.data_[i] = value.data_[i - limb_shift];
+        }
+        return result;
+    }
+
+    static GINT_CONSTEXPR14 GINT_FORCE_INLINE integer shift_right_value(const integer & value, int n) noexcept
+    {
+        if (limbs == 4)
+        {
+            integer result = value;
+            result >>= n;
+            return result;
+        }
+        if (n <= 0)
+            return value;
+
+        const bool is_signed_t = std::is_same<Signed, signed>::value;
+        const bool neg = is_signed_t && (value.data_[limbs - 1] >> 63);
+        const limb_type fill = neg ? ~limb_type(0) : limb_type(0);
+        const size_t total_bits = limbs * 64;
+        const size_t shift = static_cast<size_t>(n);
+#    if __cplusplus >= 201402L
+        integer result;
+#    else
+        integer result(uninitialized_tag{});
+#    endif
+        if (shift >= total_bits)
+        {
+            for (size_t i = 0; i < limbs; ++i)
+                result.data_[i] = fill;
+            return result;
+        }
+
+        const size_t limb_shift = shift / 64;
+        const unsigned bit_shift = static_cast<unsigned>(shift % 64);
+        const size_t count = limbs - limb_shift;
+        if (bit_shift)
+        {
+            const unsigned inv_shift = 64U - bit_shift;
+            result.data_[0] = value.data_[limb_shift] >> bit_shift;
+            for (size_t i = 1; i < count; ++i)
+            {
+                const limb_type cur = value.data_[limb_shift + i];
+                result.data_[i - 1] |= cur << inv_shift;
+                result.data_[i] = cur >> bit_shift;
+            }
+            result.data_[count - 1] |= fill << inv_shift;
+        }
+        else
+        {
+            for (size_t i = 0; i < count; ++i)
+                result.data_[i] = value.data_[i + limb_shift];
+        }
+        for (size_t i = count; i < limbs; ++i)
+            result.data_[i] = fill;
+        return result;
+    }
+#endif
+
+public:
     // Increment and decrement
     GINT_CONSTEXPR14 integer & operator++() noexcept
     {
@@ -1798,6 +1983,7 @@ public:
         return integer(lhs) ^ rhs;
     }
 
+#if GINT_GCC_TUNED_PATHS
     GINT_CONSTEXPR14 friend integer operator<<(integer lhs, int n) noexcept
     {
         lhs <<= n;
@@ -1809,6 +1995,33 @@ public:
         lhs >>= n;
         return lhs;
     }
+#else
+    template <size_t L = limbs, typename std::enable_if<(L <= 8), int>::type = 0>
+    GINT_CONSTEXPR14 friend integer operator<<(integer lhs, int n) noexcept
+    {
+        lhs <<= n;
+        return lhs;
+    }
+
+    template <size_t L = limbs, typename std::enable_if<(L > 8), int>::type = 0>
+    GINT_CONSTEXPR14 friend integer operator<<(const integer & lhs, int n) noexcept
+    {
+        return shift_left_value(lhs, n);
+    }
+
+    template <size_t L = limbs, typename std::enable_if<(L <= 4), int>::type = 0>
+    GINT_CONSTEXPR14 friend integer operator>>(integer lhs, int n) noexcept
+    {
+        lhs >>= n;
+        return lhs;
+    }
+
+    template <size_t L = limbs, typename std::enable_if<(L > 4), int>::type = 0>
+    GINT_CONSTEXPR14 friend integer operator>>(const integer & lhs, int n) noexcept
+    {
+        return shift_right_value(lhs, n);
+    }
+#endif
 
     // Multiplication is left non-constexpr due to helper internals
     friend integer operator*(const integer & lhs, const integer & rhs) noexcept
@@ -3896,3 +4109,4 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_ENABLE_POSITIVE_LIMB_DIV_FASTPATH
 #undef GINT_ENABLE_POSITIVE_LIMB_REM_FASTPATH
 #undef GINT_ENABLE_X86_64_HW_SMALL_DIVMOD
+#undef GINT_WIDE_SHIFT_INLINE

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -185,6 +185,18 @@
 #    define GINT_ENABLE_X86_64_HW_SMALL_DIVMOD GINT_ARCH_X86_64
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_TWO_LIMB_LARGE_DIVISOR_FASTPATH
+#    define GINT_ENABLE_AARCH64_TWO_LIMB_LARGE_DIVISOR_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#endif
+
+#ifndef GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH
+#    define GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#endif
+
+#ifndef GINT_ENABLE_AARCH64_TWO_LIMB_POSITIVE_POW2_DIV_FASTPATH
+#    define GINT_ENABLE_AARCH64_TWO_LIMB_POSITIVE_POW2_DIV_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#endif
+
 #if GINT_X86_64_GCC_TUNED_PATHS
 #    define GINT_WIDE_SHIFT_INLINE inline GINT_NOINLINE GINT_COLD
 #else
@@ -2238,6 +2250,10 @@ public:
         {
             lhs_neg = lhs.data_[limbs - 1] >> 63;
             rhs_neg = divisor.data_[limbs - 1] >> 63;
+#if GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH
+            if (lhs_neg && rhs_neg && negative_negative_div_quotient_is_zero(lhs, divisor))
+                return integer();
+#endif
             const limb_type min_magnitude = static_cast<limb_type>(1ULL << 63);
             // 快路径：仅当最高 limb 匹配补码最小值时再调用 is_min_value，避免普通负数走慢分支。
             if (lhs_neg)
@@ -3322,10 +3338,23 @@ private:
     }
 
     template <size_t L = limbs>
-    static GINT_FORCE_INLINE typename std::enable_if<(L < 16), bool>::type
+    static GINT_FORCE_INLINE typename std::enable_if<(L < 16 && L != 2), bool>::type
     positive_power_of_two_fastpath_divisor(const integer &, int &) noexcept
     {
         return false;
+    }
+
+    template <size_t L = limbs>
+    static GINT_FORCE_INLINE typename std::enable_if<(L == 2), bool>::type
+    positive_power_of_two_fastpath_divisor(const integer & v, int & bit_index) noexcept
+    {
+#if GINT_ENABLE_AARCH64_TWO_LIMB_POSITIVE_POW2_DIV_FASTPATH
+        return positive_power_of_two_value(v, bit_index);
+#else
+        (void)v;
+        (void)bit_index;
+        return false;
+#endif
     }
 
     static GINT_FORCE_INLINE integer div_by_positive_power_of_two(integer lhs, int pow_bit) noexcept
@@ -3341,6 +3370,32 @@ private:
             return result;
         }
         return lhs >> pow_bit;
+    }
+
+    template <size_t L = limbs>
+    static GINT_FORCE_INLINE typename std::enable_if<(L == 2), bool>::type
+    negative_negative_div_quotient_is_zero(const integer & lhs, const integer & rhs) noexcept
+    {
+#if GINT_ARCH_AARCH64
+        // For two negative two's-complement values, larger raw bits mean smaller magnitude.
+        unsigned result;
+        __asm__("cmp %[lhs_hi], %[rhs_hi]\n"
+                "ccmp %[lhs_lo], %[rhs_lo], #0, eq\n"
+                "cset %w[result], hi"
+                : [result] "=r"(result)
+                : [lhs_hi] "r"(lhs.data_[1]), [rhs_hi] "r"(rhs.data_[1]), [lhs_lo] "r"(lhs.data_[0]), [rhs_lo] "r"(rhs.data_[0])
+                : "cc");
+        return result != 0;
+#else
+        return lhs.data_[1] > rhs.data_[1] || (lhs.data_[1] == rhs.data_[1] && lhs.data_[0] > rhs.data_[0]);
+#endif
+    }
+
+    template <size_t L = limbs>
+    static GINT_FORCE_INLINE typename std::enable_if<(L != 2), bool>::type
+    negative_negative_div_quotient_is_zero(const integer &, const integer &) noexcept
+    {
+        return false;
     }
 
     static integer div_by_positive_limb(integer lhs, limb_type divisor) noexcept
@@ -3523,11 +3578,33 @@ private:
     template <size_t L = limbs>
     static typename std::enable_if<(L >= 2), integer>::type div_128(const integer & lhs, const integer & rhs) noexcept
     {
+        integer result;
+        if (GINT_UNLIKELY((rhs.data_[1] | rhs.data_[0]) == 0))
+            return result;
+#if GINT_ENABLE_AARCH64_TWO_LIMB_LARGE_DIVISOR_FASTPATH
+        if (rhs.data_[1] >= (limb_type(1) << 62))
+        {
+            limb_type rem_hi = lhs.data_[1];
+            limb_type rem_lo = lhs.data_[0];
+            limb_type q = 0;
+            for (limb_type i = 0; i < 3; ++i)
+            {
+                if (rem_hi < rhs.data_[1] || (rem_hi == rhs.data_[1] && rem_lo < rhs.data_[0]))
+                    break;
+                limb_type next_lo = rem_lo - rhs.data_[0];
+                limb_type borrow = rem_lo < rhs.data_[0];
+                rem_hi = rem_hi - rhs.data_[1] - borrow;
+                rem_lo = next_lo;
+                ++q;
+            }
+            result.data_[0] = q;
+            result.data_[1] = 0;
+            return result;
+        }
+#endif
+
         unsigned __int128 a = (static_cast<unsigned __int128>(lhs.data_[1]) << 64) | lhs.data_[0];
         unsigned __int128 b = (static_cast<unsigned __int128>(rhs.data_[1]) << 64) | rhs.data_[0];
-        integer result;
-        if (GINT_UNLIKELY(b == 0))
-            return result;
         unsigned __int128 q = a / b;
         result.data_[0] = static_cast<limb_type>(q);
         result.data_[1] = static_cast<limb_type>(q >> 64);
@@ -4318,4 +4395,7 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_ENABLE_POSITIVE_LIMB_DIV_FASTPATH
 #undef GINT_ENABLE_POSITIVE_LIMB_REM_FASTPATH
 #undef GINT_ENABLE_X86_64_HW_SMALL_DIVMOD
+#undef GINT_ENABLE_AARCH64_TWO_LIMB_LARGE_DIVISOR_FASTPATH
+#undef GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH
+#undef GINT_ENABLE_AARCH64_TWO_LIMB_POSITIVE_POW2_DIV_FASTPATH
 #undef GINT_WIDE_SHIFT_INLINE

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -141,6 +141,10 @@
         (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS && __has_builtin(__builtin_addcll) && __has_builtin(__builtin_subcll))
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_UINT128_SMALL_DIVMOD
+#    define GINT_ENABLE_AARCH64_UINT128_SMALL_DIVMOD (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#endif
+
 #ifndef GINT_ENABLE_MUL4_LOW128_FASTPATH
 #    define GINT_ENABLE_MUL4_LOW128_FASTPATH GINT_NON_X86_GCC_TUNED_PATHS
 #endif
@@ -2906,6 +2910,16 @@ private:
             }
             return static_cast<limb_type>(data_[0] & (div - 1));
         }
+#if GINT_ENABLE_AARCH64_UINT128_SMALL_DIVMOD
+        if (limbs == 2 && div > 0xFFFFFFFFULL)
+        {
+            const u128 num = (static_cast<u128>(data_[1]) << 64) | data_[0];
+            const u128 q = num / div;
+            quotient.data_[0] = static_cast<limb_type>(q);
+            quotient.data_[1] = static_cast<limb_type>(q >> 64);
+            return static_cast<limb_type>(num % div);
+        }
+#endif
 #if GINT_ENABLE_X86_64_HW_SMALL_DIVMOD
 #    if GINT_CLANG_TUNED_PATHS
         if (div != 10000000000000000000ULL)
@@ -3072,6 +3086,14 @@ private:
 
         if ((div & (div - 1)) == 0)
             return static_cast<limb_type>(data_[0] & (div - 1));
+
+#if GINT_ENABLE_AARCH64_UINT128_SMALL_DIVMOD
+        if (limbs == 2 && div > 0xFFFFFFFFULL)
+        {
+            const u128 num = (static_cast<u128>(data_[1]) << 64) | data_[0];
+            return static_cast<limb_type>(num % div);
+        }
+#endif
 
 #if GINT_ENABLE_X86_64_HW_SMALL_DIVMOD
         {
@@ -4266,6 +4288,7 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_X86_64_GCC_TUNED_PATHS
 #undef GINT_NON_X86_GCC_TUNED_PATHS
 #undef GINT_ENABLE_AARCH64_LIMB_ASM
+#undef GINT_ENABLE_AARCH64_UINT128_SMALL_DIVMOD
 #undef GINT_ENABLE_AARCH64_WIDE_ADDSUB_BUILTINS
 #undef GINT_ENABLE_X86_64_ADD_INTRINSICS
 #undef GINT_ENABLE_X86_64_WIDE_ADD_INTRINSICS

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -136,6 +136,11 @@
 #    define GINT_ENABLE_X86_64_SUB_INTRINSICS (GINT_ARCH_X86_64 && (GINT_GCC_TUNED_PATHS || GINT_CLANG_TUNED_PATHS))
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_WIDE_ADDSUB_BUILTINS
+#    define GINT_ENABLE_AARCH64_WIDE_ADDSUB_BUILTINS \
+        (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS && __has_builtin(__builtin_addcll) && __has_builtin(__builtin_subcll))
+#endif
+
 #ifndef GINT_ENABLE_MUL4_LOW128_FASTPATH
 #    define GINT_ENABLE_MUL4_LOW128_FASTPATH GINT_NON_X86_GCC_TUNED_PATHS
 #endif
@@ -362,6 +367,17 @@ GINT_FORCE_INLINE void add_limbs_runtime(uint64_t * lhs, const uint64_t * rhs) n
         lhs[i] = static_cast<uint64_t>(r);
     }
     return;
+#elif GINT_ENABLE_AARCH64_WIDE_ADDSUB_BUILTINS
+    unsigned long long carry = 0;
+    for (size_t i = 0; i < L; ++i)
+    {
+        unsigned long long carry_out;
+        const unsigned long long r
+            = __builtin_addcll(static_cast<unsigned long long>(lhs[i]), static_cast<unsigned long long>(rhs[i]), carry, &carry_out);
+        lhs[i] = static_cast<uint64_t>(r);
+        carry = carry_out;
+    }
+    return;
 #endif
     add_limbs_scalar<L>(lhs, rhs);
 }
@@ -469,6 +485,17 @@ GINT_FORCE_INLINE void sub_limbs_runtime(uint64_t * lhs, const uint64_t * rhs) n
         lhs[i] = static_cast<uint64_t>(r);
     }
     return;
+#elif GINT_ENABLE_AARCH64_WIDE_ADDSUB_BUILTINS
+    unsigned long long borrow = 0;
+    for (size_t i = 0; i < L; ++i)
+    {
+        unsigned long long borrow_out;
+        const unsigned long long r
+            = __builtin_subcll(static_cast<unsigned long long>(lhs[i]), static_cast<unsigned long long>(rhs[i]), borrow, &borrow_out);
+        lhs[i] = static_cast<uint64_t>(r);
+        borrow = borrow_out;
+    }
+    return;
 #endif
     sub_limbs_scalar<L>(lhs, rhs);
 }
@@ -567,6 +594,17 @@ GINT_FORCE_INLINE void add_limbs_copy_runtime(uint64_t * dst, const uint64_t * l
         unsigned long long r;
         carry = _addcarry_u64(carry, static_cast<unsigned long long>(lhs[i]), static_cast<unsigned long long>(rhs[i]), &r);
         dst[i] = static_cast<uint64_t>(r);
+    }
+    return;
+#elif GINT_ENABLE_AARCH64_WIDE_ADDSUB_BUILTINS
+    unsigned long long carry = 0;
+    for (size_t i = 0; i < L; ++i)
+    {
+        unsigned long long carry_out;
+        const unsigned long long r
+            = __builtin_addcll(static_cast<unsigned long long>(lhs[i]), static_cast<unsigned long long>(rhs[i]), carry, &carry_out);
+        dst[i] = static_cast<uint64_t>(r);
+        carry = carry_out;
     }
     return;
 #endif
@@ -674,6 +712,17 @@ GINT_FORCE_INLINE void sub_limbs_copy_runtime(uint64_t * dst, const uint64_t * l
         unsigned long long r;
         borrow = _subborrow_u64(borrow, static_cast<unsigned long long>(lhs[i]), static_cast<unsigned long long>(rhs[i]), &r);
         dst[i] = static_cast<uint64_t>(r);
+    }
+    return;
+#elif GINT_ENABLE_AARCH64_WIDE_ADDSUB_BUILTINS
+    unsigned long long borrow = 0;
+    for (size_t i = 0; i < L; ++i)
+    {
+        unsigned long long borrow_out;
+        const unsigned long long r
+            = __builtin_subcll(static_cast<unsigned long long>(lhs[i]), static_cast<unsigned long long>(rhs[i]), borrow, &borrow_out);
+        dst[i] = static_cast<uint64_t>(r);
+        borrow = borrow_out;
     }
     return;
 #endif
@@ -4217,6 +4266,7 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_X86_64_GCC_TUNED_PATHS
 #undef GINT_NON_X86_GCC_TUNED_PATHS
 #undef GINT_ENABLE_AARCH64_LIMB_ASM
+#undef GINT_ENABLE_AARCH64_WIDE_ADDSUB_BUILTINS
 #undef GINT_ENABLE_X86_64_ADD_INTRINSICS
 #undef GINT_ENABLE_X86_64_WIDE_ADD_INTRINSICS
 #undef GINT_ENABLE_X86_64_SUB_INTRINSICS

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -128,6 +128,10 @@
 #    define GINT_ENABLE_X86_64_ADD_INTRINSICS (GINT_ARCH_X86_64 && GINT_CLANG_TUNED_PATHS)
 #endif
 
+#ifndef GINT_ENABLE_X86_64_WIDE_ADD_INTRINSICS
+#    define GINT_ENABLE_X86_64_WIDE_ADD_INTRINSICS (GINT_ARCH_X86_64 && (GINT_GCC_TUNED_PATHS || GINT_CLANG_TUNED_PATHS))
+#endif
+
 #ifndef GINT_ENABLE_X86_64_SUB_INTRINSICS
 #    define GINT_ENABLE_X86_64_SUB_INTRINSICS (GINT_ARCH_X86_64 && (GINT_GCC_TUNED_PATHS || GINT_CLANG_TUNED_PATHS))
 #endif
@@ -349,7 +353,29 @@ GINT_CONSTEXPR14 inline void add_limbs_scalar(uint64_t * lhs, const uint64_t * r
 template <size_t L>
 GINT_FORCE_INLINE void add_limbs_runtime(uint64_t * lhs, const uint64_t * rhs) noexcept
 {
+#if GINT_ENABLE_X86_64_WIDE_ADD_INTRINSICS
+    unsigned char carry = 0;
+    for (size_t i = 0; i < L; ++i)
+    {
+        unsigned long long r;
+        carry = _addcarry_u64(carry, static_cast<unsigned long long>(lhs[i]), static_cast<unsigned long long>(rhs[i]), &r);
+        lhs[i] = static_cast<uint64_t>(r);
+    }
+    return;
+#endif
     add_limbs_scalar<L>(lhs, rhs);
+}
+
+template <>
+GINT_FORCE_INLINE void add_limbs_runtime<1>(uint64_t * lhs, const uint64_t * rhs) noexcept
+{
+    lhs[0] += rhs[0];
+}
+
+template <>
+GINT_FORCE_INLINE void add_limbs_runtime<2>(uint64_t * lhs, const uint64_t * rhs) noexcept
+{
+    add_limbs_scalar<2>(lhs, rhs);
 }
 
 template <>
@@ -434,7 +460,23 @@ GINT_CONSTEXPR14 inline void sub_limbs_scalar(uint64_t * lhs, const uint64_t * r
 template <size_t L>
 GINT_FORCE_INLINE void sub_limbs_runtime(uint64_t * lhs, const uint64_t * rhs) noexcept
 {
+#if GINT_ENABLE_X86_64_SUB_INTRINSICS
+    unsigned char borrow = 0;
+    for (size_t i = 0; i < L; ++i)
+    {
+        unsigned long long r;
+        borrow = _subborrow_u64(borrow, static_cast<unsigned long long>(lhs[i]), static_cast<unsigned long long>(rhs[i]), &r);
+        lhs[i] = static_cast<uint64_t>(r);
+    }
+    return;
+#endif
     sub_limbs_scalar<L>(lhs, rhs);
+}
+
+template <>
+GINT_FORCE_INLINE void sub_limbs_runtime<2>(uint64_t * lhs, const uint64_t * rhs) noexcept
+{
+    sub_limbs_scalar<2>(lhs, rhs);
 }
 
 template <>
@@ -518,7 +560,29 @@ GINT_CONSTEXPR14 inline void add_limbs_copy_scalar(uint64_t * dst, const uint64_
 template <size_t L>
 GINT_FORCE_INLINE void add_limbs_copy_runtime(uint64_t * dst, const uint64_t * lhs, const uint64_t * rhs) noexcept
 {
+#if GINT_ENABLE_X86_64_WIDE_ADD_INTRINSICS
+    unsigned char carry = 0;
+    for (size_t i = 0; i < L; ++i)
+    {
+        unsigned long long r;
+        carry = _addcarry_u64(carry, static_cast<unsigned long long>(lhs[i]), static_cast<unsigned long long>(rhs[i]), &r);
+        dst[i] = static_cast<uint64_t>(r);
+    }
+    return;
+#endif
     add_limbs_copy_scalar<L>(dst, lhs, rhs);
+}
+
+template <>
+GINT_FORCE_INLINE void add_limbs_copy_runtime<1>(uint64_t * dst, const uint64_t * lhs, const uint64_t * rhs) noexcept
+{
+    dst[0] = lhs[0] + rhs[0];
+}
+
+template <>
+GINT_FORCE_INLINE void add_limbs_copy_runtime<2>(uint64_t * dst, const uint64_t * lhs, const uint64_t * rhs) noexcept
+{
+    add_limbs_copy_scalar<2>(dst, lhs, rhs);
 }
 
 template <>
@@ -603,7 +667,23 @@ GINT_CONSTEXPR14 inline void sub_limbs_copy_scalar(uint64_t * dst, const uint64_
 template <size_t L>
 GINT_FORCE_INLINE void sub_limbs_copy_runtime(uint64_t * dst, const uint64_t * lhs, const uint64_t * rhs) noexcept
 {
+#if GINT_ENABLE_X86_64_SUB_INTRINSICS
+    unsigned char borrow = 0;
+    for (size_t i = 0; i < L; ++i)
+    {
+        unsigned long long r;
+        borrow = _subborrow_u64(borrow, static_cast<unsigned long long>(lhs[i]), static_cast<unsigned long long>(rhs[i]), &r);
+        dst[i] = static_cast<uint64_t>(r);
+    }
+    return;
+#endif
     sub_limbs_copy_scalar<L>(dst, lhs, rhs);
+}
+
+template <>
+GINT_FORCE_INLINE void sub_limbs_copy_runtime<2>(uint64_t * dst, const uint64_t * lhs, const uint64_t * rhs) noexcept
+{
+    sub_limbs_copy_scalar<2>(dst, lhs, rhs);
 }
 
 template <>
@@ -2078,6 +2158,10 @@ public:
         }
 #endif
 
+        int positive_pow_bit;
+        if (positive_power_of_two_fastpath_divisor(rhs, positive_pow_bit))
+            return div_by_positive_power_of_two(lhs, positive_pow_bit);
+
         bool lhs_neg = false;
         bool rhs_neg = false;
         bool lhs_is_min = false;
@@ -3138,6 +3222,42 @@ private:
 
     static GINT_FORCE_INLINE void negate_for_division(integer & v) noexcept { negate_in_place(v); }
 
+    static bool positive_power_of_two_value(const integer & v, int & bit_index) noexcept
+    {
+        if (std::is_same<Signed, signed>::value && (v.data_[limbs - 1] >> 63))
+            return false;
+        return is_power_of_two(v, bit_index);
+    }
+
+    template <size_t L = limbs>
+    static GINT_FORCE_INLINE typename std::enable_if<(L >= 16), bool>::type
+    positive_power_of_two_fastpath_divisor(const integer & v, int & bit_index) noexcept
+    {
+        return v.data_[0] == 0 && positive_power_of_two_value(v, bit_index);
+    }
+
+    template <size_t L = limbs>
+    static GINT_FORCE_INLINE typename std::enable_if<(L < 16), bool>::type
+    positive_power_of_two_fastpath_divisor(const integer &, int &) noexcept
+    {
+        return false;
+    }
+
+    static GINT_FORCE_INLINE integer div_by_positive_power_of_two(integer lhs, int pow_bit) noexcept
+    {
+        if (std::is_same<Signed, signed>::value && (lhs.data_[limbs - 1] >> 63))
+        {
+            const limb_type min_magnitude = static_cast<limb_type>(1ULL << 63);
+            if (GINT_UNLIKELY(lhs.data_[limbs - 1] == min_magnitude && is_min_value(lhs)))
+                return div_unsigned_path(lhs, integer(1) << pow_bit, true, false, true, false);
+            negate_for_division(lhs);
+            integer result = lhs >> pow_bit;
+            negate_for_division(result);
+            return result;
+        }
+        return lhs >> pow_bit;
+    }
+
     static integer div_by_positive_limb(integer lhs, limb_type divisor) noexcept
     {
         integer result;
@@ -4098,6 +4218,7 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_NON_X86_GCC_TUNED_PATHS
 #undef GINT_ENABLE_AARCH64_LIMB_ASM
 #undef GINT_ENABLE_X86_64_ADD_INTRINSICS
+#undef GINT_ENABLE_X86_64_WIDE_ADD_INTRINSICS
 #undef GINT_ENABLE_X86_64_SUB_INTRINSICS
 #undef GINT_GCC_TUNED_PATHS
 #undef GINT_CLANG_TUNED_PATHS

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -173,6 +173,10 @@
 #    define GINT_ENABLE_POSITIVE_LIMB_DIV_FASTPATH GINT_GCC_TUNED_PATHS
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_LIMB2_POSITIVE_LIMB_DIV_FASTPATH
+#    define GINT_ENABLE_AARCH64_LIMB2_POSITIVE_LIMB_DIV_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#endif
+
 #ifndef GINT_ENABLE_POSITIVE_LIMB_REM_FASTPATH
 #    define GINT_ENABLE_POSITIVE_LIMB_REM_FASTPATH (GINT_CLANG_TUNED_PATHS || GINT_ARCH_X86_64)
 #endif
@@ -2208,6 +2212,16 @@ public:
         {
             GINT_DIVZERO_CHECK(positive_limb_divisor == 0);
             return div_by_positive_limb(lhs, positive_limb_divisor);
+        }
+#elif GINT_ENABLE_AARCH64_LIMB2_POSITIVE_LIMB_DIV_FASTPATH
+        if (limbs == 2)
+        {
+            limb_type positive_limb_divisor;
+            if (positive_single_limb_value(rhs, positive_limb_divisor))
+            {
+                GINT_DIVZERO_CHECK(positive_limb_divisor == 0);
+                return div_by_positive_limb(lhs, positive_limb_divisor);
+            }
         }
 #endif
 
@@ -4289,6 +4303,7 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_NON_X86_GCC_TUNED_PATHS
 #undef GINT_ENABLE_AARCH64_LIMB_ASM
 #undef GINT_ENABLE_AARCH64_UINT128_SMALL_DIVMOD
+#undef GINT_ENABLE_AARCH64_LIMB2_POSITIVE_LIMB_DIV_FASTPATH
 #undef GINT_ENABLE_AARCH64_WIDE_ADDSUB_BUILTINS
 #undef GINT_ENABLE_X86_64_ADD_INTRINSICS
 #undef GINT_ENABLE_X86_64_WIDE_ADD_INTRINSICS

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -148,6 +148,10 @@
 #    define GINT_ENABLE_X86_64_GCC_MUL4_U64_FASTPATH (GINT_ARCH_X86_64 && GINT_GCC_TUNED_PATHS)
 #endif
 
+#ifndef GINT_ENABLE_WIDE_SINGLE_LIMB_MUL_FASTPATH
+#    define GINT_ENABLE_WIDE_SINGLE_LIMB_MUL_FASTPATH 1
+#endif
+
 #ifndef GINT_ENABLE_REM_QUOTIENT_MUL_FASTPATH
 #    define GINT_ENABLE_REM_QUOTIENT_MUL_FASTPATH GINT_GCC_TUNED_PATHS
 #endif
@@ -1040,9 +1044,17 @@ mul_limbs<4>(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, c
 }
 
 template <size_t L>
+GINT_NOINLINE bool
+mul_try_single_limb_operand(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept;
+
+template <size_t L>
 GINT_FORCE_INLINE void
 mul_limbs_result(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept
 {
+#if GINT_ENABLE_WIDE_SINGLE_LIMB_MUL_FASTPATH
+    if (L > 4 && GINT_UNLIKELY(lhs[L - 1] == 0 || rhs[L - 1] == 0) && mul_try_single_limb_operand<L>(res, lhs, rhs))
+        return;
+#endif
     for (size_t i = 0; i < L; ++i)
         res[i] = 0;
     mul_limbs<L>(res, lhs, rhs);
@@ -1060,6 +1072,62 @@ GINT_FORCE_INLINE void
 mul_limbs_result<4>(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept
 {
     mul_limbs<4>(res, lhs, rhs);
+}
+
+template <size_t L>
+GINT_FORCE_INLINE bool limbs_zero_above(const uint64_t * data, size_t first) noexcept
+{
+    if (data[L - 1] != 0)
+        return false;
+    for (size_t i = first; i < L; ++i)
+    {
+        if (data[i] != 0)
+            return false;
+    }
+    return true;
+}
+
+template <size_t L>
+GINT_FORCE_INLINE void mul_single_limb_product(uint64_t * res, uint64_t lhs, uint64_t rhs) noexcept
+{
+    const unsigned __int128 product = static_cast<unsigned __int128>(lhs) * rhs;
+    res[0] = static_cast<uint64_t>(product);
+    if (L > 1)
+        res[1] = static_cast<uint64_t>(product >> 64);
+    for (size_t i = 2; i < L; ++i)
+        res[i] = 0;
+}
+
+template <size_t L>
+GINT_FORCE_INLINE void mul_limbs_by_limb_result(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, uint64_t rhs) noexcept
+{
+    unsigned __int128 carry = 0;
+    for (size_t i = 0; i < L; ++i)
+    {
+        unsigned __int128 cur = static_cast<unsigned __int128>(lhs[i]) * rhs + carry;
+        res[i] = static_cast<uint64_t>(cur);
+        carry = cur >> 64;
+    }
+}
+
+template <size_t L>
+GINT_NOINLINE bool
+mul_try_single_limb_operand(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept
+{
+    if (limbs_zero_above<L>(rhs, 1))
+    {
+        if (limbs_zero_above<L>(lhs, 1))
+            mul_single_limb_product<L>(res, lhs[0], rhs[0]);
+        else
+            mul_limbs_by_limb_result<L>(res, lhs, rhs[0]);
+        return true;
+    }
+    if (limbs_zero_above<L>(lhs, 1))
+    {
+        mul_limbs_by_limb_result<L>(res, rhs, lhs[0]);
+        return true;
+    }
+    return false;
 }
 
 template <size_t L>
@@ -1745,9 +1813,9 @@ public:
     // Multiplication is left non-constexpr due to helper internals
     friend integer operator*(const integer & lhs, const integer & rhs) noexcept
     {
+        integer result(uninitialized_tag{});
         // Dispatch to the limb-wise multiplication routine which selects the
         // appropriate algorithm based on operand size.
-        integer result(uninitialized_tag{});
         detail::mul_limbs_result<limbs>(result.data_, lhs.data_, rhs.data_);
         return result;
     }

--- a/tests/arithmetic_divmod_test.cpp
+++ b/tests/arithmetic_divmod_test.cpp
@@ -166,6 +166,17 @@ TEST(WideIntegerDivision, SignedMinDividedByItself)
     EXPECT_EQ(min % min, S128(0));
 }
 
+TEST(WideIntegerDivision, SignedNegative128OverLargerNegativeIsZero)
+{
+    using S128 = gint::integer<128, signed>;
+    const S128 min = std::numeric_limits<S128>::min();
+    const S128 lhs = min + S128(12345);
+    const S128 rhs = min + S128(7);
+
+    EXPECT_EQ(lhs / rhs, S128(0));
+    EXPECT_EQ(lhs % rhs, lhs);
+}
+
 TEST(WideIntegerDivision, SignedSmallDivisorInt64Min)
 {
     using S256 = gint::integer<256, signed>;
@@ -609,6 +620,19 @@ TEST(WideIntegerDivision, Div128SingleLimbPath)
 
     U64 z = 0;
     EXPECT_EQ(TestAccess<U64>::div_128(a, z), U64(0));
+}
+
+TEST(WideIntegerDivision, Div128LargeDivisorSmallQuotient)
+{
+    using U128 = gint::integer<128, unsigned>;
+    const U128 divisor = (U128(1) << 126) + U128(7);
+
+    EXPECT_EQ(TestAccess<U128>::div_128(divisor - U128(1), divisor), U128(0));
+    for (uint64_t expected = 1; expected <= 3; ++expected)
+    {
+        const U128 lhs = divisor * U128(expected) + U128(11);
+        EXPECT_EQ(TestAccess<U128>::div_128(lhs, divisor), U128(expected));
+    }
 }
 
 TEST(WideIntegerDivision, DivLargeBreak)

--- a/tests/arithmetic_mul_test.cpp
+++ b/tests/arithmetic_mul_test.cpp
@@ -119,6 +119,25 @@ TEST(WideIntegerMultiplication, UInt1024_WideTimesWide_Generic)
     EXPECT_EQ(prod, sum);
 }
 
+TEST(WideIntegerMultiplication, UInt1024_LowLimbOperands)
+{
+    using U1024 = gint::integer<1024, unsigned>;
+    const uint64_t lhs64 = 0x123456789abcdef0ULL;
+    const uint64_t rhs64 = 0x10fedcba98765432ULL;
+
+    const U1024 low_product = U1024(lhs64) * U1024(rhs64);
+    const unsigned __int128 expected = static_cast<unsigned __int128>(lhs64) * rhs64;
+    EXPECT_EQ(low_product, U1024(expected));
+
+    U1024 wide = 0;
+    wide += U1024(0x1122334455667788ULL);
+    wide += U1024(0x99aabbccddeeff00ULL) << 256;
+    wide += U1024(0x0102030405060708ULL) << 768;
+
+    const U1024 by_u32 = wide * U1024(7);
+    EXPECT_EQ(by_u32, wide + wide + wide + wide + wide + wide + wide);
+}
+
 // Multiplication by power-of-two equals left shift (wide×wide trigger)
 TEST(WideIntegerMultiplication, UInt256_MulByPow2EqualsShift)
 {

--- a/tests/shift_test.cpp
+++ b/tests/shift_test.cpp
@@ -1,6 +1,108 @@
 #include <gint/gint.h>
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace
+{
+template <typename Int>
+using TestAccess = gint::detail::integer_test_access<Int::bits, typename Int::signed_tag>;
+
+template <typename Int>
+Int patterned_value(uint64_t salt)
+{
+    Int value = 0;
+    for (std::size_t i = 0; i < Int::limbs; ++i)
+    {
+        uint64_t limb = 0x9e3779b97f4a7c15ULL * static_cast<uint64_t>(i + 1);
+        limb ^= salt + (static_cast<uint64_t>(i) << 32);
+        limb ^= limb >> 29;
+        TestAccess<Int>::limb(value, i) = limb;
+    }
+    return value;
+}
+
+template <typename Int>
+Int reference_left_shift(const Int & input, std::size_t shift)
+{
+    Int result = 0;
+    if (shift >= Int::bits)
+        return result;
+
+    const std::size_t limb_shift = shift / 64;
+    const unsigned bit_shift = static_cast<unsigned>(shift % 64);
+    for (std::size_t i = 0; i < Int::limbs; ++i)
+    {
+        typename Int::limb_type part = 0;
+        if (i >= limb_shift)
+        {
+            const std::size_t src = i - limb_shift;
+            part = TestAccess<Int>::limb(input, src);
+            if (bit_shift)
+            {
+                part <<= bit_shift;
+                if (src)
+                    part |= TestAccess<Int>::limb(input, src - 1) >> (64U - bit_shift);
+            }
+        }
+        TestAccess<Int>::limb(result, i) = part;
+    }
+    return result;
+}
+
+template <typename Int>
+Int reference_right_shift(const Int & input, std::size_t shift)
+{
+    const bool is_signed_t = std::is_same<typename Int::signed_tag, signed>::value;
+    const bool neg = is_signed_t && (TestAccess<Int>::limb(input, Int::limbs - 1) >> 63);
+    const typename Int::limb_type fill = neg ? ~typename Int::limb_type(0) : typename Int::limb_type(0);
+
+    Int result = 0;
+    if (shift >= Int::bits)
+    {
+        for (std::size_t i = 0; i < Int::limbs; ++i)
+            TestAccess<Int>::limb(result, i) = fill;
+        return result;
+    }
+
+    const std::size_t limb_shift = shift / 64;
+    const unsigned bit_shift = static_cast<unsigned>(shift % 64);
+    for (std::size_t i = 0; i < Int::limbs; ++i)
+    {
+        const std::size_t src = i + limb_shift;
+        typename Int::limb_type part = fill;
+        if (src < Int::limbs)
+        {
+            part = TestAccess<Int>::limb(input, src);
+            if (bit_shift)
+            {
+                part >>= bit_shift;
+                if (src + 1 < Int::limbs)
+                    part |= TestAccess<Int>::limb(input, src + 1) << (64U - bit_shift);
+                else
+                    part |= fill << (64U - bit_shift);
+            }
+        }
+        TestAccess<Int>::limb(result, i) = part;
+    }
+    return result;
+}
+
+template <typename Int>
+void expect_shift_matches_reference(const Int & value)
+{
+    const std::size_t shifts[] = {1, 31, 63, 64, 65, 73, 127, 191, 255, 319, 511, Int::bits - 1, Int::bits};
+    for (std::size_t i = 0; i < sizeof(shifts) / sizeof(shifts[0]); ++i)
+    {
+        const int shift = static_cast<int>(shifts[i]);
+        EXPECT_EQ(value << shift, reference_left_shift(value, shifts[i])) << "left shift " << shift;
+        EXPECT_EQ(value >> shift, reference_right_shift(value, shifts[i])) << "right shift " << shift;
+    }
+}
+} // namespace
+
 TEST(WideIntegerShift, Basic)
 {
     gint::integer<128, unsigned> a = 1;
@@ -162,4 +264,19 @@ TEST(WideIntegerShift, EdgeCasesSigned512Negative)
     t >>= 600; // >= total_bits
     // Arithmetic shift of negative by >= width yields -1
     EXPECT_EQ(t, S512(-1));
+}
+
+TEST(WideIntegerShift, GenericWideUnsignedMatchesReference)
+{
+    expect_shift_matches_reference(patterned_value<gint::integer<128, unsigned>>(0x123456789abcdef0ULL));
+    expect_shift_matches_reference(patterned_value<gint::integer<512, unsigned>>(0x0fedcba987654321ULL));
+    expect_shift_matches_reference(patterned_value<gint::integer<1024, unsigned>>(0xa5a5a5a55a5a5a5aULL));
+}
+
+TEST(WideIntegerShift, GenericWideSignedRightShiftMatchesReference)
+{
+    using S512 = gint::integer<512, signed>;
+    S512 value = patterned_value<S512>(0x4242424242424242ULL);
+    TestAccess<S512>::limb(value, S512::limbs - 1) |= uint64_t(1) << 63;
+    expect_shift_matches_reference(value);
 }


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`Div/LargeDivisor128`；回归哨兵过滤器 `Sub/NoBorrow|Div/Pow2Divisor|Mod/SmallDivisor64|Div/LargeDivisor128|Div/SimilarMagnitude2`
- 环境：本机 AppleClang 21.0.0 / arm64，`BENCH_BITS=128`，base 为 `codex/int128-small-divmod-optimization`

## 做了什么

- 为 AArch64/Clang 的 128 位负数同号除法增加 raw-limb 商为 0 快路径。
- 为 128 位正 power-of-two 除数启用提前分流，避免该路径受外层除法逻辑影响。
- 为两 limb `div_128` 的大除数小商场景增加最多 3 次减法的 fastpath。
- 增加有符号负数商为 0 回归测试，以及 unsigned `div_128` 大除数商 0..3 覆盖。

## 结果

- median 对比当前 vs PR103 baseline：
  - `Div/LargeDivisor128/gint`: `2.644ns -> 1.046ns`, `2.53x`
  - `Sub/NoBorrow/gint`: `0.3736ns -> 0.3731ns`
  - `Div/Pow2Divisor/gint`: `2.578ns -> 2.536ns`
  - `Mod/SmallDivisor64/gint`: `5.119ns -> 4.972ns`
  - `Div/SimilarMagnitude2/gint`: `61.68ns -> 61.60ns`
- 当前竞品 median：
  - `Div/LargeDivisor128`: gint `1.046ns`, ClickHouse `1.712ns`, Boost `2.812ns`
- 结果文件：
  - `runs/local/int128-large-div/current_focused_repetitions_final_20260603.json`
  - `runs/local/worktrees/pr103-base/runs/local/int128-large-div/pr103_focused_repetitions_20260603.json`

## 验证

- `clang-format` + `git diff --check`
- 本机 AppleClang：`make TEST_BUILD_DIR=runs/local/build-test-int128-large-div test`，371/371 passed
- Docker/GCC：`docker run --rm -t -v "$PWD":/work -w /work gint:centos8 make TEST_BUILD_DIR=runs/docker/build-test-int128-large-div test`，371/371 passed
- AArch64 对比性能：`BENCH_BITS=128` 聚焦 repetitions，`--benchmark_repetitions=3`

## 风险

- AArch64 raw-limb 比较使用 GNU-style inline asm；默认只在 AArch64/Clang-tuned fastpath 中启用。
- x86/GCC 路径默认不启用该优化，已用 Docker/GCC 测试确认可编译并通过。
