### PR TITLE
perf: speed up 1024-bit low-limb multiplication

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1269,6 +1269,17 @@ template <size_t L>
 GINT_NOINLINE bool
 mul_try_single_limb_operand(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept
 {
+    if (GINT_UNLIKELY((lhs[L - 1] | rhs[L - 1]) == 0))
+    {
+        uint64_t high_or = 0;
+        for (size_t i = 1; i < L; ++i)
+            high_or |= lhs[i] | rhs[i];
+        if (high_or == 0)
+        {
+            mul_single_limb_product<L>(res, lhs[0], rhs[0]);
+            return true;
+        }
+    }
     if (limbs_zero_above<L>(rhs, 1))
     {
         if (limbs_zero_above<L>(lhs, 1))


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`Mul/(U64xU64|HighxHigh|WideTimesU64)`，重点覆盖 1024-bit `Mul/U64xU64`，并用 `HighxHigh` / `WideTimesU64` 做哨兵。
- 环境：本机 AppleClang 21.0.0.21000101；Docker/GCC 8.5.0 (`gint:centos8`)。

## 做了什么

- 在已有 wide single-limb multiply probe 中，先识别“两边操作数都只占低 limb”的形态并直接写入 single-limb product。
- 保持真正 wide×wide 和 wide×u64 的既有路径不变；改动限定在已有 `GINT_ENABLE_WIDE_SINGLE_LIMB_MUL_FASTPATH` 保护的探测函数内。

## 结果

- 本机 1024-bit：`Mul/U64xU64/gint` median `3.617ns -> 1.862ns`，约 `1.94x`；同轮 `HighxHigh` `48.153ns -> 48.058ns`，`WideTimesU64` `3.581ns -> 3.591ns`。
- 本机 1024-bit High-only 长跑：`HighxHigh/gint` `49.226ns -> 49.266ns`，约 `+0.08%`。
- 本机 512-bit 长跑：`U64xU64/gint` `2.311ns -> 2.219ns`，约 `1.04x`；`HighxHigh` `+0.09%`，`WideTimesU64` `-0.02%`。
- Docker/GCC 1024-bit：`U64xU64/gint` `3.656ns -> 2.501ns`，约 `1.46x`；`HighxHigh` `+0.17%`，`WideTimesU64` `+0.08%`。
- 结果文件：`runs/local/int1024-u64-mul/`、`runs/local/int512-u64-mul/`、`runs/docker/int1024-u64-mul/`。

## 验证

- `clang-format -i include/gint/gint.h`
- `git diff --check`
- 本机单元测试：371/371 passed。
- Docker/GCC 单元测试：371/371 passed。
- 本机与 Docker/GCC 聚焦对比测试见结果文件。

## 风险

- 主要风险是额外探测影响其它乘法形态；已用 512/1024 的 `HighxHigh` 和 `WideTimesU64` 哨兵验证，未观察到稳定回退。