### PR TITLE
perf: speed up aarch64 int128 limb division

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -197,6 +197,10 @@
 #    define GINT_ENABLE_AARCH64_TWO_LIMB_POSITIVE_POW2_DIV_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH
+#    define GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#endif
+
 #if GINT_X86_64_GCC_TUNED_PATHS
 #    define GINT_WIDE_SHIFT_INLINE inline GINT_NOINLINE GINT_COLD
 #else
@@ -2239,6 +2243,10 @@ public:
 #elif GINT_ENABLE_AARCH64_LIMB2_POSITIVE_LIMB_DIV_FASTPATH
         if (limbs == 2)
         {
+            int positive_pow_bit;
+            if (positive_power_of_two_fastpath_divisor(rhs, positive_pow_bit))
+                return div_by_positive_power_of_two(lhs, positive_pow_bit);
+
             limb_type positive_limb_divisor;
             if (positive_single_limb_value(rhs, positive_limb_divisor))
             {
@@ -3414,6 +3422,11 @@ private:
         integer result;
         if (std::is_same<Signed, signed>::value && (lhs.data_[limbs - 1] >> 63))
         {
+#if GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH
+            if (GINT_UNLIKELY(divisor > 0xFFFFFFFFULL && (divisor & (divisor - 1)) != 0)
+                && div_signed_int128_by_positive_limb(lhs, divisor, result))
+                return result;
+#endif
             negate_for_division(lhs);
             lhs.div_mod_small(divisor, result);
             negate_for_division(result);
@@ -3422,6 +3435,25 @@ private:
 
         lhs.div_mod_small(divisor, result);
         return result;
+    }
+
+    template <size_t L = limbs, typename std::enable_if<(L == 2 && std::is_same<Signed, signed>::value), int>::type = 0>
+    static GINT_FORCE_INLINE bool div_signed_int128_by_positive_limb(const integer & lhs, limb_type divisor, integer & result) noexcept
+    {
+        using u128 = unsigned __int128;
+        using s128 = __int128;
+        const u128 lhs_raw = (static_cast<u128>(lhs.data_[1]) << 64) | lhs.data_[0];
+        const s128 quotient = static_cast<s128>(lhs_raw) / static_cast<s128>(divisor);
+        const u128 quotient_raw = static_cast<u128>(quotient);
+        result.data_[0] = static_cast<limb_type>(quotient_raw);
+        result.data_[1] = static_cast<limb_type>(quotient_raw >> 64);
+        return true;
+    }
+
+    template <size_t L = limbs, typename std::enable_if<(L != 2 || !std::is_same<Signed, signed>::value), int>::type = 0>
+    static GINT_FORCE_INLINE bool div_signed_int128_by_positive_limb(const integer &, limb_type, integer &) noexcept
+    {
+        return false;
     }
 
     static integer rem_by_positive_limb(const integer & lhs, limb_type divisor) noexcept
@@ -4409,4 +4441,5 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_ENABLE_AARCH64_TWO_LIMB_LARGE_DIVISOR_FASTPATH
 #undef GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH
 #undef GINT_ENABLE_AARCH64_TWO_LIMB_POSITIVE_POW2_DIV_FASTPATH
+#undef GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH
 #undef GINT_WIDE_SHIFT_INLINE


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`Div/SmallDivisor64/gint`，同时检查 `Div/SmallDivisor32/gint`、`Div/Pow2Divisor/gint`、`Div/LargeDivisor128/gint`、`Mod/SmallDivisor64/gint` 与 128-bit full matrix。
- 环境：本机 AppleClang/arm64，`CMAKE_BUILD_TYPE=Release`，`BENCH_ARGS="--benchmark_min_time=0.2s"`。

## 做了什么

- 让 AArch64/Clang 的 128-bit 正 power-of-two divisor 先走已有 shift division 路径，避免落入 small-limb division。
- 增加 `GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH`，仅在 AArch64/Clang、128-bit signed、负 dividend、正且非 power-of-two 的 64-bit limb divisor 上使用原生 `__int128` 计算商。

## 结果

- `Div/SmallDivisor64/gint`：`5.70878 ns -> 5.1714 ns`，约 `1.104x`。
- `Div/Pow2Divisor/gint`：`2.52551 ns -> 2.28702 ns`，约 `1.104x`。
- `Div/LargeDivisor128/gint`：`1.05116 ns -> 1.00651 ns`，约 `1.044x`。
- `Div/SmallDivisor32/gint`：`3.80278 ns -> 3.80925 ns`，`+0.17%`。
- 128-bit full matrix 未发现 `>3%` 的 gint 回退。
- 结果文件：`runs/local/post-pr105-scan/int128_full_20260603.json`、`runs/local/int128_direct_limb_div_final_full.json`、`runs/local/int128_direct_limb_div_pow2_precheck_key_reps.json`。

## 验证

- `make TEST_BUILD_DIR=runs/local/build test`：371/371 passed。
- `bench-compare-full` 128-bit full matrix。
- 关键用例 `--benchmark_repetitions=5 --benchmark_report_aggregates_only=true` 复测。

## 风险

- 快路径通过宏隔离，并限制在 AArch64/Clang 的 128-bit signed 场景；非 AArch64、非 Clang、非 128-bit 宽度不启用该 signed limb division fastpath。
