### PR TITLE
perf: speed up aarch64 int1024 xor

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -201,6 +201,10 @@
 #    define GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH
+#    define GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#endif
+
 #if GINT_X86_64_GCC_TUNED_PATHS
 #    define GINT_WIDE_SHIFT_INLINE inline GINT_NOINLINE GINT_COLD
 #else
@@ -878,6 +882,30 @@ bit_xor_limbs<4>(uint64_t * GINT_RESTRICT dst, const uint64_t * GINT_RESTRICT lh
     dst[2] = lhs[2] ^ rhs[2];
     dst[3] = lhs[3] ^ rhs[3];
 }
+
+#if GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH
+template <>
+GINT_CONSTEXPR14 GINT_FORCE_INLINE void
+bit_xor_limbs<16>(uint64_t * GINT_RESTRICT dst, const uint64_t * GINT_RESTRICT lhs, const uint64_t * GINT_RESTRICT rhs) noexcept
+{
+    dst[0] = lhs[0] ^ rhs[0];
+    dst[1] = lhs[1] ^ rhs[1];
+    dst[2] = lhs[2] ^ rhs[2];
+    dst[3] = lhs[3] ^ rhs[3];
+    dst[4] = lhs[4] ^ rhs[4];
+    dst[5] = lhs[5] ^ rhs[5];
+    dst[6] = lhs[6] ^ rhs[6];
+    dst[7] = lhs[7] ^ rhs[7];
+    dst[8] = lhs[8] ^ rhs[8];
+    dst[9] = lhs[9] ^ rhs[9];
+    dst[10] = lhs[10] ^ rhs[10];
+    dst[11] = lhs[11] ^ rhs[11];
+    dst[12] = lhs[12] ^ rhs[12];
+    dst[13] = lhs[13] ^ rhs[13];
+    dst[14] = lhs[14] ^ rhs[14];
+    dst[15] = lhs[15] ^ rhs[15];
+}
+#endif
 
 GINT_FORCE_INLINE void mul_limbs4_by_limb(uint64_t * GINT_RESTRICT res, const uint64_t * GINT_RESTRICT lhs, uint64_t rhs) noexcept
 {
@@ -4442,4 +4470,5 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH
 #undef GINT_ENABLE_AARCH64_TWO_LIMB_POSITIVE_POW2_DIV_FASTPATH
 #undef GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH
+#undef GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH
 #undef GINT_WIDE_SHIFT_INLINE


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`^Bitwise/`，重点是 `Bitwise/Xor` 的 1024-bit AArch64/AppleClang 表现
- 环境：本机 AppleClang/arm64，`Apple clang version 21.0.0`，`CMAKE_BUILD_TYPE=Release`

## 做了什么

- 为 AArch64/Clang 增加 `bit_xor_limbs<16>` 展开特化，用于 1024-bit XOR。
- 通过 `GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH` 宏隔离，避免影响其它工具链。

## 结果

- `Bitwise/Xor/gint`：`1.476ns -> 1.453ns`，约 `1.6%` 提升。
- `Bitwise/Xor` 相对 ClickHouse 的差距从约 `2.8%` 降到约 `1.3%`，1024-bit 完整结果中已无 `>2%` 的竞品短板。
- 1024-bit 完整矩阵未发现 `gint` 项目 `>3%` 回退。
- 结果文件：`runs/local/int1024_xor_unroll_full.json`、`runs/local/int1024_xor_unroll_key_reps.json`、`runs/local/int1024_xor_unroll_macro_off_key_reps.json`。

## 验证

- `make TEST_BUILD_DIR=runs/local/build test`
- 1024-bit 完整对比矩阵：`runs/local/int1024_xor_unroll_full.json`
- 128/256/512 bitwise 检查：`runs/local/int128_xor_unroll_bitwise_check.json`、`runs/local/int256_xor_unroll_bitwise_check.json`、`runs/local/int512_xor_unroll_bitwise_check.json`

## 风险

- 该优化只对 AArch64/Clang 默认开启；其它工具链默认不启用。
- 收益幅度较小，但变更范围很窄，且完整矩阵未显示实质回退。
