### PR TITLE
perf: speed up aarch64 int128 unsigned right shift

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -205,6 +205,10 @@
 #    define GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_INT128_UNSIGNED_RIGHT_SHIFT_FASTPATH
+#    define GINT_ENABLE_AARCH64_INT128_UNSIGNED_RIGHT_SHIFT_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#endif
+
 #if GINT_X86_64_GCC_TUNED_PATHS
 #    define GINT_WIDE_SHIFT_INLINE inline GINT_NOINLINE GINT_COLD
 #else
@@ -1793,6 +1797,34 @@ public:
     }
 
 private:
+    template <size_t L = limbs>
+    static GINT_CONSTEXPR14 GINT_FORCE_INLINE typename std::enable_if<(L == 2 && std::is_same<Signed, signed>::value), integer>::type
+    shift_right_int128_unsigned_value(const integer & lhs, unsigned n) noexcept
+    {
+        if (GINT_UNLIKELY(n == 0))
+            return lhs;
+
+        if (GINT_UNLIKELY(n >= 128))
+        {
+            const bool neg = (lhs.data_[1] >> 63) != 0;
+            const limb_type fill = neg ? ~limb_type(0) : limb_type(0);
+            integer result(uninitialized_tag{});
+            result.data_[0] = fill;
+            result.data_[1] = fill;
+            return result;
+        }
+
+        using s128 = __int128;
+        using u128 = unsigned __int128;
+        const u128 raw = (static_cast<u128>(lhs.data_[1]) << 64) | lhs.data_[0];
+        const s128 shifted = static_cast<s128>(raw) >> n;
+        const u128 shifted_raw = static_cast<u128>(shifted);
+        integer result(uninitialized_tag{});
+        result.data_[0] = static_cast<limb_type>(shifted_raw);
+        result.data_[1] = static_cast<limb_type>(shifted_raw >> 64);
+        return result;
+    }
+
     GINT_CONSTEXPR14 GINT_WIDE_SHIFT_INLINE integer & shift_left_assign_wide(size_t limb_shift, unsigned bit_shift) noexcept
     {
         if (bit_shift)
@@ -2206,6 +2238,17 @@ public:
     {
         lhs >>= n;
         return lhs;
+    }
+
+    template <
+        size_t L = limbs,
+        typename std::enable_if<
+            (GINT_ENABLE_AARCH64_INT128_UNSIGNED_RIGHT_SHIFT_FASTPATH && L == 2 && std::is_same<Signed, signed>::value),
+            int>::type
+        = 0>
+    GINT_CONSTEXPR14 friend integer operator>>(const integer & lhs, unsigned n) noexcept
+    {
+        return shift_right_int128_unsigned_value(lhs, n);
     }
 
     template <size_t L = limbs, typename std::enable_if<(L > 4), int>::type = 0>
@@ -4471,4 +4514,5 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_ENABLE_AARCH64_TWO_LIMB_POSITIVE_POW2_DIV_FASTPATH
 #undef GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH
 #undef GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH
+#undef GINT_ENABLE_AARCH64_INT128_UNSIGNED_RIGHT_SHIFT_FASTPATH
 #undef GINT_WIDE_SHIFT_INLINE


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`Shift/RightVariable`，重点是 128-bit AArch64/AppleClang 的 `unsigned` shift count 路径
- 环境：本机 AppleClang/arm64，`Apple clang version 21.0.0`，`CMAKE_BUILD_TYPE=Release`

## 做了什么

- 为 AArch64/Clang 增加 signed Int128 的 `operator>>(const integer&, unsigned)` 专用重载。
- 使用 native `__int128` 算术右移处理 `unsigned` shift count，让 benchmark 的 unsigned 计数走快路径。
- 通过 `GINT_ENABLE_AARCH64_INT128_UNSIGNED_RIGHT_SHIFT_FASTPATH` 宏隔离，并保留原 `int` 重载，避免影响除法内部使用的右移路径。

## 结果

- `Shift/RightVariable/gint`：macro-off `1.118ns`，结果 `0.840ns`，约 `1.33x` 加速。
- 相对 Boost 的差距从约 `1.48x` 缩小到约 `1.11x`。
- 同源码 macro-off 完整矩阵对比中，敏感项无实质回退：
  - `Div/LargeDivisor128`：`0.999ns -> 1.004ns`
  - `Div/SmallDivisor64`：`5.197ns -> 5.237ns`
  - `Mod/SmallDivisor64`：`5.069ns -> 5.078ns`
  - `Div/Pow2Divisor`：`2.289ns -> 2.315ns`
- 结果文件：`runs/local/int128_unsigned_rshift_stacked_macro_off_full.json`、`runs/local/int128_unsigned_rshift_stacked_full.json`、`runs/local/int128_unsigned_rshift_final_anomaly_reps21.json`、`runs/local/int128_unsigned_rshift_final_boundary_reps21.json`。

## 验证

- `make TEST_BUILD_DIR=runs/local/build test`
- 128-bit 完整对比矩阵：`runs/local/int128_unsigned_rshift_stacked_full.json`
- 同源码 macro-off 完整矩阵：`runs/local/int128_unsigned_rshift_stacked_macro_off_full.json`
- 异常/边界项 21 次复测：`runs/local/int128_unsigned_rshift_final_anomaly_reps21.json`、`runs/local/int128_unsigned_rshift_final_boundary_reps21.json`

## 风险

- 该优化只在 AArch64/Clang 默认启用；其它工具链默认不启用。
- 只覆盖 `unsigned` shift count；使用 `int` shift count 的调用保持原路径。
