### PR TITLE
perf: speed up aarch64 int128 positive limb modulo

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -201,6 +201,11 @@
 #    define GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_INT128_POSITIVE_LIMB_REM_FASTPATH
+#    define GINT_ENABLE_AARCH64_INT128_POSITIVE_LIMB_REM_FASTPATH \
+        (GINT_ENABLE_POSITIVE_LIMB_REM_FASTPATH && GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#endif
+
 #ifndef GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH
 #    define GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
 #endif
@@ -2440,10 +2445,35 @@ public:
     friend integer operator%(integer lhs, const integer & rhs)
     {
         GINT_MODZERO_CHECK(rhs.is_zero());
+#if GINT_ENABLE_AARCH64_INT128_POSITIVE_LIMB_REM_FASTPATH
+        if (limbs == 2)
+        {
+            limb_type positive_limb_divisor;
+            if (positive_single_limb_value(rhs, positive_limb_divisor))
+            {
+                integer result;
+                if (std::is_same<Signed, signed>::value && (lhs.data_[1] >> 63))
+                {
+                    using Unsigned = integer<Bits, unsigned>;
+                    Unsigned lhs_mag;
+                    copy_abs_magnitude(lhs_mag, lhs, true);
+                    result.data_[0] = lhs_mag.mod_small(positive_limb_divisor);
+                    negate_for_division(result);
+                    return result;
+                }
+
+                result.data_[0] = lhs.mod_small(positive_limb_divisor);
+                return result;
+            }
+        }
+#endif
 #if GINT_ENABLE_POSITIVE_LIMB_REM_FASTPATH
-        limb_type positive_limb_divisor;
-        if (positive_single_limb_value(rhs, positive_limb_divisor))
-            return rem_by_positive_limb(lhs, positive_limb_divisor);
+        if (!(GINT_ENABLE_AARCH64_INT128_POSITIVE_LIMB_REM_FASTPATH && limbs == 2))
+        {
+            limb_type positive_limb_divisor;
+            if (positive_single_limb_value(rhs, positive_limb_divisor))
+                return rem_by_positive_limb(lhs, positive_limb_divisor);
+        }
 #endif
 #if GINT_GCC_TUNED_PATHS
         if (std::is_same<Signed, signed>::value)
@@ -4513,6 +4543,7 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH
 #undef GINT_ENABLE_AARCH64_TWO_LIMB_POSITIVE_POW2_DIV_FASTPATH
 #undef GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH
+#undef GINT_ENABLE_AARCH64_INT128_POSITIVE_LIMB_REM_FASTPATH
 #undef GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH
 #undef GINT_ENABLE_AARCH64_INT128_UNSIGNED_RIGHT_SHIFT_FASTPATH
 #undef GINT_WIDE_SHIFT_INLINE


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`^(Mul/U64xU64|Div/Pow2Divisor|Div/SmallDivisor64|Mod/SmallDivisor64|Mod/SimilarMagnitude)/`
- 环境：本机 AppleClang/arm64，`BENCH_BITS=128`，`--benchmark_min_time=0.2s`

## 做了什么

- 为 AArch64/Clang 的 128-bit positive single-limb modulo 增加专用 fastpath。
- 新增 `GINT_ENABLE_AARCH64_INT128_POSITIVE_LIMB_REM_FASTPATH`，默认服从 `GINT_ENABLE_POSITIVE_LIMB_REM_FASTPATH` 总开关。
- 保持 `/` 的 positive-limb helper 不变，避免影响 small-divisor division 路径。

## 结果

- 9 次重复边界复核：
  - `Mod/SmallDivisor64/gint`: 5.002 ns -> 4.736 ns，约 1.056x。
  - `Div/SmallDivisor64/gint`: 5.221 ns -> 5.335 ns，约 1.022x 波动，低于 3% 回退阈值。
  - `Mul/U64xU64/gint`: 0.465 ns -> 0.465 ns，无回退。
  - `Mod/SimilarMagnitude/gint`: 48.421 ns -> 48.436 ns，无回退。
- 128-bit full matrix:
  - `Mod/SmallDivisor64/gint`: 4.972 ns -> 4.643 ns，约 1.071x。
  - full 单次中 `Mul/U64xU64/gint` 出现 4.6% 波动，但 9 次重复边界复核为 0.998x ratio，判定非稳定回退。
- 结果文件：
  - `runs/local/int128_mod_direct_skipold_macro_off_boundary_reps9.json`
  - `runs/local/int128_mod_direct_skipold_boundary_reps9.json`
  - `runs/local/int128_mod_direct_skipold_macro_off_full.json`
  - `runs/local/int128_mod_direct_skipold_full.json`

## 验证

- `git diff --check`
- `make TEST_BUILD_DIR=runs/local/build test`
- `make BENCH_BITS=128 BENCH_BUILD_DIR=runs/local/build-bench-int128-mod-direct-off bench-compare-full ...`
- `make BENCH_BITS=128 BENCH_BUILD_DIR=runs/local/build-bench bench-compare-full ...`

## 风险

- 该 fastpath 仅默认启用于 AArch64/Clang 且 `limbs == 2` 的 positive single-limb modulo；其它宽度仍走原路径。
