### PR TITLE
perf: speed up aarch64 int128 right shift guard

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1806,27 +1806,24 @@ private:
     static GINT_CONSTEXPR14 GINT_FORCE_INLINE typename std::enable_if<(L == 2 && std::is_same<Signed, signed>::value), integer>::type
     shift_right_int128_unsigned_value(const integer & lhs, unsigned n) noexcept
     {
-        if (GINT_UNLIKELY(n == 0))
-            return lhs;
-
-        if (GINT_UNLIKELY(n >= 128))
+        if (GINT_LIKELY(n < 128U))
         {
-            const bool neg = (lhs.data_[1] >> 63) != 0;
-            const limb_type fill = neg ? ~limb_type(0) : limb_type(0);
+            using s128 = __int128;
+            using u128 = unsigned __int128;
+            const u128 raw = (static_cast<u128>(lhs.data_[1]) << 64) | lhs.data_[0];
+            const s128 shifted = static_cast<s128>(raw) >> n;
+            const u128 shifted_raw = static_cast<u128>(shifted);
             integer result(uninitialized_tag{});
-            result.data_[0] = fill;
-            result.data_[1] = fill;
+            result.data_[0] = static_cast<limb_type>(shifted_raw);
+            result.data_[1] = static_cast<limb_type>(shifted_raw >> 64);
             return result;
         }
 
-        using s128 = __int128;
-        using u128 = unsigned __int128;
-        const u128 raw = (static_cast<u128>(lhs.data_[1]) << 64) | lhs.data_[0];
-        const s128 shifted = static_cast<s128>(raw) >> n;
-        const u128 shifted_raw = static_cast<u128>(shifted);
+        const bool neg = (lhs.data_[1] >> 63) != 0;
+        const limb_type fill = neg ? ~limb_type(0) : limb_type(0);
         integer result(uninitialized_tag{});
-        result.data_[0] = static_cast<limb_type>(shifted_raw);
-        result.data_[1] = static_cast<limb_type>(shifted_raw >> 64);
+        result.data_[0] = fill;
+        result.data_[1] = fill;
         return result;
     }
 


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`^Shift/RightVariable/`，并用 128-bit deficit 过滤器做回归复测
- 环境：本机 AppleClang/arm64，`BENCH_BUILD_DIR=runs/local/build-bench`，`CMAKE_BUILD_TYPE=Release`

## 做了什么

- 将 AArch64/Clang 128-bit signed 右移 fastpath 从两个冷分支判断重排为单个 `n < 128U` 常见路径判断。
- `n >= 128` 仍保留符号填充分支，`n == 0` 由 native 128-bit shift 路径自然处理，语义不变。

## 结果

- `Shift/RightVariable/gint_mean`：`0.8453 ns -> 0.8012 ns`，约 `1.055x`。
- 同一 128-bit deficit 过滤器复测中，`Div/SmallDivisor32`、`Div/SmallDivisor64`、`Mod/SmallDivisor64`、`Div/SimilarMagnitude`、`Div/SimilarMagnitude2`、`Bitwise/And`、`Bitwise/Xor` 未出现实质回退。
- 128-bit 完整对比矩阵复测中，`Shift/RightVariable/gint_mean` 为 `0.803 ns`，`Div/LargeDivisor128/gint_mean` 仍约 `1.01 ns`。
- 结果文件：
  - `runs/local/int128_rshift_single_guard_deficits_reps11.json`
  - `runs/local/int128_rshift_single_guard_full_reps5.json`
  - 基线：`runs/local/current_pr109_int128_deficits_reps11.json`

## 验证

- `make TEST_BUILD_DIR=runs/local/build test`
- `git diff --check`
- `make BENCH_BITS=128 BENCH_BUILD_DIR=runs/local/build-bench bench-compare-full BENCH_ARGS="'--benchmark_filter=^(Bitwise/And|Bitwise/Xor|Shift/RightVariable|Div/SmallDivisor32|Div/SmallDivisor64|Mod/SmallDivisor64|Div/SimilarMagnitude|Div/SimilarMagnitude2)/' --benchmark_min_time=0.2s --benchmark_repetitions=11 --benchmark_report_aggregates_only=true --benchmark_out=runs/local/int128_rshift_single_guard_deficits_reps11.json --benchmark_out_format=json"`
- `make BENCH_BITS=128 BENCH_BUILD_DIR=runs/local/build-bench bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s --benchmark_repetitions=5 --benchmark_report_aggregates_only=true --benchmark_out=runs/local/int128_rshift_single_guard_full_reps5.json --benchmark_out_format=json"`

## 风险

- 仅影响 `limbs == 2` 且 `Signed == signed` 的 unsigned shift-count 右移 fastpath；其它宽度不会实例化该 helper。
