### PR TITLE
perf: speed up aarch64 gcc wide left shifts

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -214,6 +214,10 @@
 #    define GINT_ENABLE_AARCH64_INT128_UNSIGNED_RIGHT_SHIFT_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_GCC_WIDE_LEFT_SHIFT_UNSIGNED_FASTPATH
+#    define GINT_ENABLE_AARCH64_GCC_WIDE_LEFT_SHIFT_UNSIGNED_FASTPATH (GINT_ARCH_AARCH64 && GINT_GCC_TUNED_PATHS)
+#endif
+
 #if GINT_X86_64_GCC_TUNED_PATHS
 #    define GINT_WIDE_SHIFT_INLINE inline GINT_NOINLINE GINT_COLD
 #else
@@ -1889,20 +1893,10 @@ private:
         return *this;
     }
 
-#if !GINT_GCC_TUNED_PATHS
-    static GINT_CONSTEXPR14 GINT_FORCE_INLINE integer shift_left_value(const integer & value, int n) noexcept
+#if !GINT_GCC_TUNED_PATHS || GINT_ENABLE_AARCH64_GCC_WIDE_LEFT_SHIFT_UNSIGNED_FASTPATH
+    static GINT_CONSTEXPR14 GINT_FORCE_INLINE integer shift_left_value_by_size(const integer & value, size_t shift) noexcept
     {
-        if (limbs == 4)
-        {
-            integer result = value;
-            result <<= n;
-            return result;
-        }
-        if (n <= 0)
-            return value;
-
         const size_t total_bits = limbs * 64;
-        const size_t shift = static_cast<size_t>(n);
 #    if __cplusplus >= 201402L
         integer result;
 #    else
@@ -1940,6 +1934,20 @@ private:
                 result.data_[i] = value.data_[i - limb_shift];
         }
         return result;
+    }
+
+    static GINT_CONSTEXPR14 GINT_FORCE_INLINE integer shift_left_value(const integer & value, int n) noexcept
+    {
+        if (limbs == 4)
+        {
+            integer result = value;
+            result <<= n;
+            return result;
+        }
+        if (n <= 0)
+            return value;
+
+        return shift_left_value_by_size(value, static_cast<size_t>(n));
     }
 
     static GINT_CONSTEXPR14 GINT_FORCE_INLINE integer shift_right_value(const integer & value, int n) noexcept
@@ -2215,6 +2223,15 @@ public:
         lhs <<= n;
         return lhs;
     }
+
+#    if GINT_ENABLE_AARCH64_GCC_WIDE_LEFT_SHIFT_UNSIGNED_FASTPATH
+    template <size_t L = limbs, typename std::enable_if<(L > 8), int>::type = 0>
+    GINT_CONSTEXPR14 friend integer operator<<(const integer & lhs, unsigned n) noexcept
+    {
+        const size_t shift = static_cast<size_t>(n);
+        return shift_left_value_by_size(lhs, shift);
+    }
+#    endif
 
     GINT_CONSTEXPR14 friend integer operator>>(integer lhs, int n) noexcept
     {


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`^(Div/(Pow2Divisor|SimilarMagnitude|SimilarMagnitude2)|Mod/SimilarMagnitude|Shift/(LeftVariable|RightVariable))/(gint|ClickHouse|Boost)$`
- 环境：Docker/GCC aarch64，`CMAKE_BUILD_TYPE=Release`，`--benchmark_min_time=0.2s --benchmark_repetitions=7`

## 做了什么

- 为 aarch64/GCC 增加宽整数 `unsigned` 左移值返回 fast path，命中 `Int1024 << unsigned` 这类 variable shift benchmark。
- 将左移值返回 helper 拆出 `size_t` 入口，避免新增 `unsigned` overload 依赖 `int` 截断转换。
- 通过 `GINT_ENABLE_AARCH64_GCC_WIDE_LEFT_SHIFT_UNSIGNED_FASTPATH` 隔离到 aarch64/GCC。

## 结果

- Docker/GCC aarch64 Int1024：`Shift/LeftVariable/gint_mean` 从 8.170ns 降至 4.089ns，约 1.998x。
- 同组回归检查中，其余 gint 目标项最大波动约 1.22%，未见实质回退。
- 当前结果中 `Shift/LeftVariable` 已快于 ClickHouse 4.934ns 与 Boost 13.959ns。
- 结果文件：`runs/docker/aarch64_gcc_left_unsigned_off_int1024_target_reps7.json`、`runs/docker/aarch64_gcc_left_unsigned_on_int1024_target_reps7.json`。

## 验证

- `make TEST_BUILD_DIR=runs/local/build test`
- `git diff --check`
- 本机 AppleClang Int1024 同组 A/B：最大波动 0.83%，未见实质回退。结果文件：`runs/local/appleclang_left_refactor_base_int1024_target_reps7.json`、`runs/local/appleclang_left_refactor_current_int1024_target_reps7.json`。
- 本机 AppleClang Int512 shift 聚焦复测：`Shift/LeftVariable` -0.23%，`Shift/RightVariable` +3.28%。结果文件：`runs/local/appleclang_left_refactor_base_int512_shift_reps11.json`、`runs/local/appleclang_left_refactor_current_int512_shift_reps11.json`。

## 风险

- 该 fast path 仅默认启用于 aarch64/GCC，其他平台只受到等价 helper 拆分影响；已用本机 AppleClang 512/1024 目标项做 A/B 检查。
