### PR TITLE
perf: speed up aarch64 gcc large modulo

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -3851,7 +3851,7 @@ private:
     static integer rem_unsigned_magnitude_with_large_direct(const integer & lhs, const integer & divisor) noexcept
     {
 #if GINT_ENABLE_AARCH64_GCC_REM_LARGE_DIRECT_FASTPATH
-        if (limbs > 4 && GINT_UNLIKELY((divisor.data_[limbs - 1] | divisor.data_[limbs - 2]) != 0))
+        if (limbs >= 4 && GINT_UNLIKELY((divisor.data_[limbs - 1] | divisor.data_[limbs - 2]) != 0))
         {
             const size_t divisor_limbs = used_limbs(divisor);
             int pow_bit;
@@ -4112,10 +4112,38 @@ private:
         return carry != 0 || borrow != 0;
     }
 
+    static bool rem_sub_mul_limb_full_width(integer & lhs, const integer & divisor, limb_type q) noexcept
+    {
+        unsigned __int128 carry = 0;
+        limb_type borrow = 0;
+        for (size_t i = 0; i < limbs; ++i)
+        {
+            unsigned __int128 p = static_cast<unsigned __int128>(divisor.data_[i]) * q + carry;
+            carry = p >> 64;
+
+            unsigned __int128 subtrahend = static_cast<unsigned __int128>(static_cast<limb_type>(p)) + borrow;
+            limb_type next_borrow = static_cast<unsigned __int128>(lhs.data_[i]) < subtrahend;
+            lhs.data_[i] = static_cast<limb_type>(static_cast<unsigned __int128>(lhs.data_[i]) - subtrahend);
+            borrow = next_borrow;
+        }
+        return carry != 0 || borrow != 0;
+    }
+
     static void rem_add_divisor(integer & lhs, const integer & divisor, size_t div_limbs) noexcept
     {
         unsigned __int128 carry = 0;
         for (size_t i = 0; i < div_limbs; ++i)
+        {
+            unsigned __int128 sum = static_cast<unsigned __int128>(lhs.data_[i]) + divisor.data_[i] + carry;
+            lhs.data_[i] = static_cast<limb_type>(sum);
+            carry = sum >> 64;
+        }
+    }
+
+    static void rem_add_divisor_full_width(integer & lhs, const integer & divisor) noexcept
+    {
+        unsigned __int128 carry = 0;
+        for (size_t i = 0; i < limbs; ++i)
         {
             unsigned __int128 sum = static_cast<unsigned __int128>(lhs.data_[i]) + divisor.data_[i] + carry;
             lhs.data_[i] = static_cast<limb_type>(sum);
@@ -4129,8 +4157,15 @@ private:
             return lhs;
 
         const limb_type q = rem_estimate_single_limb_quotient(lhs, divisor, div_limbs);
-        if (rem_sub_mul_limb(lhs, divisor, div_limbs, q))
+        if (div_limbs == limbs)
+        {
+            if (rem_sub_mul_limb_full_width(lhs, divisor, q))
+                rem_add_divisor_full_width(lhs, divisor);
+        }
+        else if (rem_sub_mul_limb(lhs, divisor, div_limbs, q))
+        {
             rem_add_divisor(lhs, divisor, div_limbs);
+        }
         return lhs;
     }
 #endif

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -224,6 +224,10 @@
 #    endif
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_GCC_REM_LARGE_DIRECT_FASTPATH
+#    define GINT_ENABLE_AARCH64_GCC_REM_LARGE_DIRECT_FASTPATH (GINT_ARCH_AARCH64 && GINT_GCC_TUNED_PATHS)
+#endif
+
 #if GINT_X86_64_GCC_TUNED_PATHS
 #    define GINT_WIDE_SHIFT_INLINE inline GINT_NOINLINE GINT_COLD
 #else
@@ -3781,7 +3785,11 @@ private:
         copy_abs_magnitude(lhs_mag, lhs, lhs_neg);
         copy_abs_magnitude(rhs_mag, rhs, rhs_neg);
 
+#if GINT_ENABLE_AARCH64_GCC_REM_LARGE_DIRECT_FASTPATH
+        Unsigned rem_mag = Unsigned::rem_unsigned_magnitude_with_large_direct(lhs_mag, rhs_mag);
+#else
         Unsigned rem_mag = Unsigned::rem_unsigned_magnitude(lhs_mag, rhs_mag);
+#endif
         integer result(uninitialized_tag{});
         for (size_t i = 0; i < limbs; ++i)
             result.data_[i] = rem_mag.data_[i];
@@ -3838,6 +3846,21 @@ private:
         quotient *= divisor;
         result -= quotient;
         return result;
+    }
+
+    static integer rem_unsigned_magnitude_with_large_direct(const integer & lhs, const integer & divisor) noexcept
+    {
+#if GINT_ENABLE_AARCH64_GCC_REM_LARGE_DIRECT_FASTPATH
+        if (limbs > 4 && GINT_UNLIKELY((divisor.data_[limbs - 1] | divisor.data_[limbs - 2]) != 0))
+        {
+            const size_t divisor_limbs = used_limbs(divisor);
+            int pow_bit;
+            if (is_power_of_two(divisor, pow_bit))
+                return lhs & (divisor - integer(1));
+            return rem_large(lhs, divisor, divisor_limbs);
+        }
+#endif
+        return rem_unsigned_magnitude(lhs, divisor);
     }
 
     static bool is_min_value(const integer & v) noexcept
@@ -4036,6 +4059,87 @@ private:
             quotient.data_[j] = static_cast<limb_type>(qhat);
         }
         return quotient;
+    }
+
+    static GINT_NOINLINE integer rem_large(integer lhs, const integer & divisor, size_t div_limbs) noexcept
+    {
+        size_t n = limbs;
+        while (n > 0 && lhs.data_[n - 1] == 0)
+            --n;
+        if (GINT_UNLIKELY(div_limbs == 0) || n < div_limbs)
+            return lhs;
+
+        std::array<limb_type, limbs + 1> u = {};
+        std::array<limb_type, limbs> v = {};
+
+        const int shift = __builtin_clzll(divisor.data_[div_limbs - 1]);
+        limb_type carry = lshift_limbs_to(lhs.data_, n, u.data(), shift);
+        u[n] = carry;
+
+        carry = lshift_limbs_to(divisor.data_, div_limbs, v.data(), shift);
+
+        for (int j = static_cast<int>(n - div_limbs); j >= 0; --j)
+        {
+            unsigned __int128 numerator = (static_cast<unsigned __int128>(u[j + div_limbs]) << 64) | u[j + div_limbs - 1];
+            unsigned __int128 qhat = numerator / v[div_limbs - 1];
+            unsigned __int128 rhat = numerator - qhat * v[div_limbs - 1];
+
+            while (qhat == (static_cast<unsigned __int128>(1) << 64) || qhat * v[div_limbs - 2] > ((rhat << 64) | u[j + div_limbs - 2]))
+            {
+                --qhat;
+                rhat += v[div_limbs - 1];
+                if (rhat >= (static_cast<unsigned __int128>(1) << 64))
+                    break;
+            }
+
+            unsigned __int128 borrow = 0;
+            for (size_t i = 0; i < div_limbs; ++i)
+            {
+                unsigned __int128 p = qhat * v[i] + borrow;
+                if (u[j + i] < static_cast<limb_type>(p))
+                {
+                    u[j + i] = static_cast<limb_type>(static_cast<unsigned __int128>(u[j + i]) - p);
+                    borrow = (p >> 64) + 1;
+                }
+                else
+                {
+                    u[j + i] = static_cast<limb_type>(static_cast<unsigned __int128>(u[j + i]) - p);
+                    borrow = p >> 64;
+                }
+            }
+            if (static_cast<unsigned __int128>(u[j + div_limbs]) < borrow)
+            {
+                unsigned __int128 carry2 = 0;
+                for (size_t i = 0; i < div_limbs; ++i)
+                {
+                    unsigned __int128 t2 = static_cast<unsigned __int128>(u[j + i]) + v[i] + carry2;
+                    u[j + i] = static_cast<limb_type>(t2);
+                    carry2 = t2 >> 64;
+                }
+                u[j + div_limbs] = static_cast<limb_type>(static_cast<unsigned __int128>(u[j + div_limbs]) + carry2);
+            }
+            else
+            {
+                u[j + div_limbs] = static_cast<limb_type>(static_cast<unsigned __int128>(u[j + div_limbs]) - borrow);
+            }
+        }
+
+        integer result;
+        if (shift == 0)
+        {
+            for (size_t i = 0; i < div_limbs; ++i)
+                result.data_[i] = u[i];
+        }
+        else
+        {
+            const int inv_shift = 64 - shift;
+            for (size_t i = 0; i < div_limbs; ++i)
+            {
+                const limb_type next = (i + 1 < div_limbs) ? u[i + 1] : 0;
+                result.data_[i] = (u[i] >> shift) | (next << inv_shift);
+            }
+        }
+        return result;
     }
 
     // Optimized specialization: full-width 256-bit divisor (divisor_limbs == 4)
@@ -4468,6 +4572,8 @@ struct integer_test_access
     static Int div_128(const Int & lhs, const Int & rhs) noexcept { return Int::div_128(lhs, rhs); }
 
     static Int div_large(Int lhs, const Int & rhs, size_t div_limbs) noexcept { return Int::div_large(lhs, rhs, div_limbs); }
+
+    static Int rem_large(Int lhs, const Int & rhs, size_t div_limbs) noexcept { return Int::rem_large(lhs, rhs, div_limbs); }
 
     static Int div_large_2(Int lhs, const Int & rhs) noexcept { return Int::div_large_2(lhs, rhs); }
 

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -4061,6 +4061,80 @@ private:
         return quotient;
     }
 
+#if GINT_ENABLE_AARCH64_GCC_REM_LARGE_DIRECT_FASTPATH
+    GINT_FORCE_INLINE static limb_type rem_left_shifted_limb_at(const limb_type * src, size_t i, int shift) noexcept
+    {
+        limb_type cur = src[i];
+        if (shift == 0)
+            return cur;
+        limb_type prev = i == 0 ? 0 : src[i - 1];
+        return static_cast<limb_type>((cur << shift) | (prev >> (64 - shift)));
+    }
+
+    static limb_type rem_estimate_single_limb_quotient(const integer & lhs, const integer & divisor, size_t div_limbs) noexcept
+    {
+        using u128 = unsigned __int128;
+        const int shift = __builtin_clzll(divisor.data_[div_limbs - 1]);
+        const limb_type vtop = rem_left_shifted_limb_at(divisor.data_, div_limbs - 1, shift);
+        const limb_type vnext = rem_left_shifted_limb_at(divisor.data_, div_limbs - 2, shift);
+        const limb_type utop = shift ? static_cast<limb_type>(lhs.data_[div_limbs - 1] >> (64 - shift)) : 0;
+        const limb_type unext = rem_left_shifted_limb_at(lhs.data_, div_limbs - 1, shift);
+        const limb_type uthird = rem_left_shifted_limb_at(lhs.data_, div_limbs - 2, shift);
+
+        u128 numerator = (static_cast<u128>(utop) << 64) | unext;
+        u128 qhat = numerator / vtop;
+        u128 rhat = numerator - qhat * vtop;
+        while (qhat == (static_cast<u128>(1) << 64) || qhat * vnext > ((rhat << 64) | uthird))
+        {
+            --qhat;
+            rhat += vtop;
+            if (rhat >= (static_cast<u128>(1) << 64))
+                break;
+        }
+
+        return static_cast<limb_type>(qhat);
+    }
+
+    static bool rem_sub_mul_limb(integer & lhs, const integer & divisor, size_t div_limbs, limb_type q) noexcept
+    {
+        unsigned __int128 carry = 0;
+        limb_type borrow = 0;
+        for (size_t i = 0; i < div_limbs; ++i)
+        {
+            unsigned __int128 p = static_cast<unsigned __int128>(divisor.data_[i]) * q + carry;
+            carry = p >> 64;
+
+            unsigned __int128 subtrahend = static_cast<unsigned __int128>(static_cast<limb_type>(p)) + borrow;
+            limb_type next_borrow = static_cast<unsigned __int128>(lhs.data_[i]) < subtrahend;
+            lhs.data_[i] = static_cast<limb_type>(static_cast<unsigned __int128>(lhs.data_[i]) - subtrahend);
+            borrow = next_borrow;
+        }
+        return carry != 0 || borrow != 0;
+    }
+
+    static void rem_add_divisor(integer & lhs, const integer & divisor, size_t div_limbs) noexcept
+    {
+        unsigned __int128 carry = 0;
+        for (size_t i = 0; i < div_limbs; ++i)
+        {
+            unsigned __int128 sum = static_cast<unsigned __int128>(lhs.data_[i]) + divisor.data_[i] + carry;
+            lhs.data_[i] = static_cast<limb_type>(sum);
+            carry = sum >> 64;
+        }
+    }
+
+    static integer rem_large_single_limb_quotient(integer lhs, const integer & divisor, size_t div_limbs) noexcept
+    {
+        if (div_limbs < 2)
+            return lhs;
+
+        const limb_type q = rem_estimate_single_limb_quotient(lhs, divisor, div_limbs);
+        if (rem_sub_mul_limb(lhs, divisor, div_limbs, q))
+            rem_add_divisor(lhs, divisor, div_limbs);
+        return lhs;
+    }
+#endif
+
     static GINT_NOINLINE integer rem_large(integer lhs, const integer & divisor, size_t div_limbs) noexcept
     {
         size_t n = limbs;
@@ -4068,6 +4142,10 @@ private:
             --n;
         if (GINT_UNLIKELY(div_limbs == 0) || n < div_limbs)
             return lhs;
+#if GINT_ENABLE_AARCH64_GCC_REM_LARGE_DIRECT_FASTPATH
+        if (n == div_limbs)
+            return rem_large_single_limb_quotient(lhs, divisor, div_limbs);
+#endif
 
         std::array<limb_type, limbs + 1> u = {};
         std::array<limb_type, limbs> v = {};

--- a/tests/arithmetic_divmod_test.cpp
+++ b/tests/arithmetic_divmod_test.cpp
@@ -938,6 +938,44 @@ TEST(WideIntegerDivision, DivLargeGenericConstructedAddbackBranch)
     EXPECT_EQ(lhs - q * divisor, divisor - U512(1));
 }
 
+TEST(WideIntegerDivision, RemLargeGenericMatchesQuotientRemainder)
+{
+    using U512 = gint::integer<512, unsigned>;
+
+    const U512 lhs = (U512(1) << 511) - U512(12345);
+    const U512 full_width_divisor = (U512(1) << 470) + U512(987654321);
+    const U512 seven_limb_divisor = (U512(1) << 436) + U512(123456789);
+
+    {
+        const U512 q = TestAccess<U512>::div_large(lhs, full_width_divisor, 8);
+        const U512 r = TestAccess<U512>::rem_large(lhs, full_width_divisor, 8);
+        EXPECT_EQ(q * full_width_divisor + r, lhs);
+        EXPECT_LT(r, full_width_divisor);
+    }
+
+    {
+        const U512 q = TestAccess<U512>::div_large(lhs, seven_limb_divisor, 7);
+        const U512 r = TestAccess<U512>::rem_large(lhs, seven_limb_divisor, 7);
+        EXPECT_EQ(q * seven_limb_divisor + r, lhs);
+        EXPECT_LT(r, seven_limb_divisor);
+    }
+}
+
+TEST(WideIntegerDivision, SignedLargeModuloMatchesQuotientRemainder)
+{
+    using I512 = gint::integer<512, signed>;
+
+    const I512 divisor = (I512(1) << 470) + I512(987654321);
+    const I512 magnitude = (I512(1) << 510) + I512(12345);
+    const I512 lhs = -magnitude;
+
+    const I512 q = lhs / divisor;
+    const I512 r = lhs % divisor;
+    EXPECT_EQ(q * divisor + r, lhs);
+    EXPECT_LT(r, I512(0));
+    EXPECT_GT(r, -divisor);
+}
+
 TEST(WideIntegerDivision, DivLarge3EarlyReturnWhenDividendShorter)
 {
     using U256 = gint::integer<256, unsigned>;

--- a/tests/arithmetic_divmod_test.cpp
+++ b/tests/arithmetic_divmod_test.cpp
@@ -1063,13 +1063,15 @@ TEST(WideIntegerDivision, MinValueUnsignedPathSignCorrection)
 
     S256 q = min / divisor;
     S256 r = min % divisor;
-    EXPECT_TRUE(static_cast<int64_t>(TestAccess<S256>::limb(q, S256::limbs - 1) >> 63)); // quotient should be negative
+    const bool q_negative = static_cast<int64_t>(TestAccess<S256>::limb(q, S256::limbs - 1) >> 63) != 0;
+    EXPECT_TRUE(q_negative);
     EXPECT_EQ(q * divisor + r, min);
 
     S256 neg_divisor = -divisor;
     S256 q2 = min / neg_divisor;
     S256 r2 = min % neg_divisor;
-    EXPECT_FALSE(static_cast<int64_t>(TestAccess<S256>::limb(q2, S256::limbs - 1) >> 63)); // quotient should be non-negative
+    const bool q2_negative = static_cast<int64_t>(TestAccess<S256>::limb(q2, S256::limbs - 1) >> 63) != 0;
+    EXPECT_FALSE(q2_negative);
     EXPECT_EQ(q2 * neg_divisor + r2, min);
 }
 


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：Int256/Int512/Int1024 `^Mod/`
- 环境：Docker/GCC aarch64；本机 AppleClang 单测对照

## 做了什么

- 为 AArch64/GCC large modulo 增加直接 remainder 路径，避免先算 quotient 再做一次全宽乘法回推 remainder。
- 对 `n == div_limbs` 且 quotient 只占一个 limb 的大取模形态，新增单 limb quotient 估算路径，直接执行 `lhs -= divisor * q`；若估算过大则 add-back 一次。
- 将 direct remainder 入口扩展到 4-limb 宽度，使 Int256 高位除数的 `Mod/SimilarMagnitude` 也走直接 remainder 路径。
- 保留 signed modulo 的符号语义，现有大取模测试覆盖 unsigned/signed 组合；同时修正一处 GCC 8/GTest 宏解析不兼容的测试写法。

## 结果

相对 PR113 原始版本，Docker/GCC aarch64 Int256：

| 用例 | PR113 原始版本 | 当前结果 | 加速比 |
| --- | ---: | ---: | ---: |
| `Mod/SimilarMagnitude/gint_mean` | 23.731153 ns | 21.180199 ns | 1.12x |
| `Mod/SmallDivisor64/gint_mean` | 12.541652 ns | 12.504509 ns | 1.00x |

当前 Docker/GCC aarch64 三方对比：

| 用例 | gint | ClickHouse | Boost |
| --- | ---: | ---: | ---: |
| Int256 `Mod/SimilarMagnitude` | 21.180199 ns | 404.176657 ns | 22.407118 ns |
| Int256 `Mod/SmallDivisor64` | 12.504509 ns | 23.588450 ns | 15.945091 ns |
| Int512 `Mod/SimilarMagnitude` | 24.522628 ns | 545.661185 ns | 26.416722 ns |
| Int512 `Mod/SmallDivisor64` | 21.878390 ns | 60.067218 ns | 42.342202 ns |
| Int1024 `Mod/SimilarMagnitude` | 41.148120 ns | 1246.805752 ns | 41.400373 ns |
| Int1024 `Mod/SmallDivisor64` | 46.976635 ns | 170.224798 ns | 109.510829 ns |

结论：

- Int256 `Mod/SimilarMagnitude` 已从落后 Boost 转为领先 Boost。
- Int512/Int1024 `Mod/SimilarMagnitude` 保持领先 Boost；`Mod/SmallDivisor64` 不触发本次新增 large modulo 路径，当前三方对比仍明显领先 ClickHouse/Boost。

结果文件：

- `runs/docker/int256_mod_pr113_direct4_result_reps7.json`
- `runs/docker/int512_mod_pr113_direct4_result_reps7.json`
- `runs/docker/int1024_mod_pr113_direct4_result_reps7.json`
- `runs/docker/worktrees/pr113-base/runs/docker/int256_mod_pr113_base_reps7.json`

## 验证

- Docker/GCC `make TEST_BUILD_DIR=runs/docker/build-test-rem-singleq test`（375/375）
- 本机 AppleClang `make TEST_BUILD_DIR=runs/local/build-test-rem-singleq test`（375/375）
- `git diff --check`

## 风险

- 新路径由 `GINT_ENABLE_AARCH64_GCC_REM_LARGE_DIRECT_FASTPATH` 控制，默认只在 AArch64/GCC tuned path 启用。
- 入口只在 divisor 的高位 limb 非零时触发；small divisor 和 power-of-two modulo 不走该路径。
