### PR TITLE
perf: speed up wide small-quotient division

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -173,6 +173,10 @@
 #    define GINT_ENABLE_POSITIVE_LIMB_DIV_FASTPATH GINT_GCC_TUNED_PATHS
 #endif
 
+#ifndef GINT_ENABLE_WIDE_SINGLE_LIMB_QUOTIENT_DIV_FASTPATH
+#    define GINT_ENABLE_WIDE_SINGLE_LIMB_QUOTIENT_DIV_FASTPATH GINT_GCC_TUNED_PATHS
+#endif
+
 #ifndef GINT_ENABLE_AARCH64_LIMB2_POSITIVE_LIMB_DIV_FASTPATH
 #    define GINT_ENABLE_AARCH64_LIMB2_POSITIVE_LIMB_DIV_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
 #endif
@@ -3966,6 +3970,73 @@ private:
         return result;
     }
 
+#if GINT_ENABLE_WIDE_SINGLE_LIMB_QUOTIENT_DIV_FASTPATH
+    GINT_FORCE_INLINE static limb_type left_shifted_limb_at(const limb_type * src, size_t i, int shift) noexcept
+    {
+        limb_type cur = src[i];
+        if (shift == 0)
+            return cur;
+        limb_type prev = i == 0 ? 0 : src[i - 1];
+        return static_cast<limb_type>((cur << shift) | (prev >> (64 - shift)));
+    }
+
+    static bool mul_by_limb_greater_than(const integer & lhs, const integer & divisor, size_t div_limbs, limb_type q) noexcept
+    {
+        if (q == 0)
+            return false;
+
+        std::array<limb_type, limbs + 1> product;
+        unsigned __int128 carry = 0;
+        for (size_t i = 0; i < div_limbs; ++i)
+        {
+            unsigned __int128 p = static_cast<unsigned __int128>(divisor.data_[i]) * q + carry;
+            product[i] = static_cast<limb_type>(p);
+            carry = p >> 64;
+        }
+        if (carry != 0)
+            return true;
+
+        for (size_t i = div_limbs; i-- > 0;)
+        {
+            if (product[i] != lhs.data_[i])
+                return product[i] > lhs.data_[i];
+        }
+        return false;
+    }
+
+    static integer div_large_single_limb_quotient(const integer & lhs, const integer & divisor, size_t div_limbs) noexcept
+    {
+        integer quotient;
+        if (div_limbs < 2)
+            return quotient;
+
+        using u128 = unsigned __int128;
+        const int shift = __builtin_clzll(divisor.data_[div_limbs - 1]);
+        const limb_type vtop = left_shifted_limb_at(divisor.data_, div_limbs - 1, shift);
+        const limb_type vnext = left_shifted_limb_at(divisor.data_, div_limbs - 2, shift);
+        const limb_type utop = shift ? static_cast<limb_type>(lhs.data_[div_limbs - 1] >> (64 - shift)) : 0;
+        const limb_type unext = left_shifted_limb_at(lhs.data_, div_limbs - 1, shift);
+        const limb_type uthird = left_shifted_limb_at(lhs.data_, div_limbs - 2, shift);
+
+        u128 numerator = (static_cast<u128>(utop) << 64) | unext;
+        u128 qhat = numerator / vtop;
+        u128 rhat = numerator - qhat * vtop;
+        while (qhat == (static_cast<u128>(1) << 64) || qhat * vnext > ((rhat << 64) | uthird))
+        {
+            --qhat;
+            rhat += vtop;
+            if (rhat >= (static_cast<u128>(1) << 64))
+                break;
+        }
+
+        limb_type q = static_cast<limb_type>(qhat);
+        while (mul_by_limb_greater_than(lhs, divisor, div_limbs, q))
+            --q;
+        quotient.data_[0] = q;
+        return quotient;
+    }
+#endif
+
     static integer div_large(integer lhs, const integer & divisor, size_t div_limbs) noexcept
     {
         integer quotient;
@@ -3974,6 +4045,10 @@ private:
             --n;
         if (GINT_UNLIKELY(div_limbs == 0) || n < div_limbs)
             return quotient;
+#if GINT_ENABLE_WIDE_SINGLE_LIMB_QUOTIENT_DIV_FASTPATH
+        if (n == div_limbs)
+            return div_large_single_limb_quotient(lhs, divisor, div_limbs);
+#endif
 
         std::array<limb_type, limbs + 1> u;
         std::array<limb_type, limbs> v;

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -3975,8 +3975,8 @@ private:
         if (GINT_UNLIKELY(div_limbs == 0) || n < div_limbs)
             return quotient;
 
-        std::array<limb_type, limbs + 1> u = {};
-        std::array<limb_type, limbs> v = {};
+        std::array<limb_type, limbs + 1> u;
+        std::array<limb_type, limbs> v;
 
         int shift = __builtin_clzll(divisor.data_[div_limbs - 1]);
         limb_type carry = lshift_limbs_to(lhs.data_, n, u.data(), shift);

--- a/tests/gcc_tuned_fastpaths_test.cpp
+++ b/tests/gcc_tuned_fastpaths_test.cpp
@@ -5,6 +5,7 @@ namespace
 {
 
 using U256 = gint::integer<256, unsigned>;
+using U512 = gint::integer<512, unsigned>;
 
 U256 make_u256(uint64_t w3, uint64_t w2, uint64_t w1, uint64_t w0)
 {
@@ -36,4 +37,20 @@ TEST(GccTunedFastpaths, UInt256FullWidthModulo)
 
     EXPECT_EQ(lhs / divisor, U256(9));
     EXPECT_EQ(lhs % divisor, remainder);
+}
+
+TEST(GccTunedFastpaths, UInt512SingleLimbQuotientDivision)
+{
+    const U512 lhs = (U512(1) << 511) - U512(17);
+
+    for (int shift : {448, 476})
+    {
+        const U512 divisor = (U512(1) << shift) + U512(123456789ULL);
+        const U512 quotient = (U512(1) << (511 - shift)) - U512(1);
+        const U512 remainder = lhs - divisor * quotient;
+
+        EXPECT_EQ(lhs / divisor, quotient);
+        EXPECT_EQ(lhs % divisor, remainder);
+        EXPECT_LT(remainder, divisor);
+    }
 }


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：Int512/Int1024 `^Div/`；连带检查 `^Mod/`
- 环境：Docker/GCC aarch64；本机 AppleClang 单测对照

## 做了什么

- 保留原有优化：`div_large` 的大 scratch array 改为不做默认清零，避免已完全覆盖写入的无效初始化。
- 新增 GCC tuned fastpath：当 dividend 与 divisor 的 used-limb 数相同、quotient 只可能占一个 limb 时，直接估算并校正单 limb quotient，避免完整 Knuth scratch 归一化和通用循环。
- 增加 U512 小商除法正确性测试，覆盖 full-width divisor 且 expected quotient 已知的形态。

## 结果

相对 PR112 基线，Docker/GCC aarch64：

| 用例 | Int512 | Int1024 |
| --- | ---: | ---: |
| `Div/SimilarMagnitude/gint_mean` | 26.136205 -> 20.467828 ns（+27.69%） | 41.748734 -> 33.745401 ns（+23.72%） |
| `Div/SimilarMagnitude2/gint_mean` | 23.008138 -> 15.209615 ns（+51.27%） | 36.519501 -> 26.147925 ns（+39.67%） |
| `Div/LargeDivisor128/gint_mean` | 40.915287 -> 39.767590 ns（+2.89%） | 85.690509 -> 82.667615 ns（+3.66%） |
| `Div/SmallDivisor32/gint_mean` | 21.487843 -> 20.873187 ns（+2.94%） | 61.750883 -> 58.335008 ns（+5.86%） |
| `Div/SmallDivisor64/gint_mean` | 23.761745 -> 23.161249 ns（+2.59%） | 52.734599 -> 49.688154 ns（+6.13%） |
| `Div/Pow2Divisor/gint_mean` | 10.162912 -> 10.174482 ns（-0.11%） | 22.142519 -> 21.508885 ns（+2.95%） |

当前 Docker/GCC aarch64 三方对比：

| 用例 | Int512 gint / ClickHouse / Boost | Int1024 gint / ClickHouse / Boost |
| --- | ---: | ---: |
| `Div/SimilarMagnitude` | 20.467828 / 513.333909 / 26.387431 ns | 33.745401 / 1190.723412 / 41.184531 ns |
| `Div/SimilarMagnitude2` | 15.209615 / 477.132484 / 21.631052 ns | 26.147925 / 1113.479216 / 32.993508 ns |

`Mod` 连带检查相对 #114 原提交：

- Int512 `Mod/SimilarMagnitude/gint_mean`：38.974671 -> 34.600036 ns（+12.64%）
- Int1024 `Mod/SimilarMagnitude/gint_mean`：81.641790 -> 70.307579 ns（+16.12%）
- `Mod/SmallDivisor64` 不经过新增 fastpath；正反序复测显示为运行顺序噪声（Int1024 forward +0.52%，reverse -0.87%）。

结果文件：

- `runs/docker/div_singleq_current_div_int512_reps7.json`
- `runs/docker/div_singleq_current_div_int1024_reps7.json`
- `runs/docker/div_singleq_current_mod_int512_reps7.json`
- `runs/docker/div_singleq_current_mod_int1024_reps7.json`
- `runs/docker/worktrees/pr112-base/runs/docker/div_array_base_div_int512_reps7.json`
- `runs/docker/worktrees/pr112-base/runs/docker/div_array_base_div_int1024_reps7.json`

## 验证

- `make TEST_BUILD_DIR=runs/local/build-div-singleq test`
- Docker/GCC `make TEST_BUILD_DIR=runs/docker/build-test-div-singleq test`
- `git diff --check`

## 风险

- 新 fastpath 由 `GINT_ENABLE_WIDE_SINGLE_LIMB_QUOTIENT_DIV_FASTPATH` 控制，默认只在 GCC tuned path 开启；AppleClang 默认不启用。
- 该路径只在 `div_large` 中 `n == div_limbs` 时触发，不改变 small divisor、power-of-two divisor、128-bit/two-limb/three-limb/four-limb专用分派。
