### PR TITLE
perf: speed up aarch64 gcc int512 shifts

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -2380,7 +2380,7 @@ public:
     }
 
 #    if GINT_ENABLE_AARCH64_GCC_WIDE_SHIFT_UNSIGNED_FASTPATH
-    template <size_t L = limbs, typename std::enable_if<(L > 8), int>::type = 0>
+    template <size_t L = limbs, typename std::enable_if<(L >= 8), int>::type = 0>
     GINT_CONSTEXPR14 friend integer operator<<(const integer & lhs, unsigned n) noexcept
     {
         const size_t shift = static_cast<size_t>(n);
@@ -2395,7 +2395,7 @@ public:
     }
 
 #    if GINT_ENABLE_AARCH64_GCC_WIDE_SHIFT_UNSIGNED_FASTPATH
-    template <size_t L = limbs, typename std::enable_if<(L > 8), int>::type = 0>
+    template <size_t L = limbs, typename std::enable_if<(L >= 8), int>::type = 0>
     GINT_CONSTEXPR14 friend integer operator>>(const integer & lhs, unsigned n) noexcept
     {
         const size_t shift = static_cast<size_t>(n);

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -2057,10 +2057,183 @@ private:
         return integer();
     }
 
+    template <size_t L = limbs>
+    static GINT_CONSTEXPR14 typename std::enable_if<(L == 8), integer>::type
+    shift_right_value_by_size_fixed8(const integer & value, size_t shift) noexcept
+    {
+        const bool is_signed_t = std::is_same<Signed, signed>::value;
+        const bool neg = is_signed_t && (value.data_[limbs - 1] >> 63);
+        const limb_type fill = neg ? ~limb_type(0) : limb_type(0);
+        const size_t total_bits = limbs * 64;
+        if (shift >= total_bits)
+        {
+#    if __cplusplus >= 201402L
+            integer result;
+#    else
+            integer result(uninitialized_tag{});
+#    endif
+            for (size_t i = 0; i < limbs; ++i)
+                result.data_[i] = fill;
+            return result;
+        }
+
+        const size_t limb_shift = shift / 64;
+        const unsigned bit_shift = static_cast<unsigned>(shift % 64);
+#    if __cplusplus >= 201402L
+        integer result;
+#    else
+        integer result(uninitialized_tag{});
+#    endif
+        const limb_type src0 = value.data_[0];
+        const limb_type src1 = value.data_[1];
+        const limb_type src2 = value.data_[2];
+        const limb_type src3 = value.data_[3];
+        const limb_type src4 = value.data_[4];
+        const limb_type src5 = value.data_[5];
+        const limb_type src6 = value.data_[6];
+        const limb_type src7 = value.data_[7];
+        limb_type out0 = fill;
+        limb_type out1 = fill;
+        limb_type out2 = fill;
+        limb_type out3 = fill;
+        limb_type out4 = fill;
+        limb_type out5 = fill;
+        limb_type out6 = fill;
+        limb_type out7 = fill;
+
+        if (bit_shift)
+        {
+            const unsigned inv_shift = 64U - bit_shift;
+            switch (limb_shift)
+            {
+                case 0:
+                    out0 = (src0 >> bit_shift) | (src1 << inv_shift);
+                    out1 = (src1 >> bit_shift) | (src2 << inv_shift);
+                    out2 = (src2 >> bit_shift) | (src3 << inv_shift);
+                    out3 = (src3 >> bit_shift) | (src4 << inv_shift);
+                    out4 = (src4 >> bit_shift) | (src5 << inv_shift);
+                    out5 = (src5 >> bit_shift) | (src6 << inv_shift);
+                    out6 = (src6 >> bit_shift) | (src7 << inv_shift);
+                    out7 = (src7 >> bit_shift) | (fill << inv_shift);
+                    break;
+                case 1:
+                    out0 = (src1 >> bit_shift) | (src2 << inv_shift);
+                    out1 = (src2 >> bit_shift) | (src3 << inv_shift);
+                    out2 = (src3 >> bit_shift) | (src4 << inv_shift);
+                    out3 = (src4 >> bit_shift) | (src5 << inv_shift);
+                    out4 = (src5 >> bit_shift) | (src6 << inv_shift);
+                    out5 = (src6 >> bit_shift) | (src7 << inv_shift);
+                    out6 = (src7 >> bit_shift) | (fill << inv_shift);
+                    break;
+                case 2:
+                    out0 = (src2 >> bit_shift) | (src3 << inv_shift);
+                    out1 = (src3 >> bit_shift) | (src4 << inv_shift);
+                    out2 = (src4 >> bit_shift) | (src5 << inv_shift);
+                    out3 = (src5 >> bit_shift) | (src6 << inv_shift);
+                    out4 = (src6 >> bit_shift) | (src7 << inv_shift);
+                    out5 = (src7 >> bit_shift) | (fill << inv_shift);
+                    break;
+                case 3:
+                    out0 = (src3 >> bit_shift) | (src4 << inv_shift);
+                    out1 = (src4 >> bit_shift) | (src5 << inv_shift);
+                    out2 = (src5 >> bit_shift) | (src6 << inv_shift);
+                    out3 = (src6 >> bit_shift) | (src7 << inv_shift);
+                    out4 = (src7 >> bit_shift) | (fill << inv_shift);
+                    break;
+                case 4:
+                    out0 = (src4 >> bit_shift) | (src5 << inv_shift);
+                    out1 = (src5 >> bit_shift) | (src6 << inv_shift);
+                    out2 = (src6 >> bit_shift) | (src7 << inv_shift);
+                    out3 = (src7 >> bit_shift) | (fill << inv_shift);
+                    break;
+                case 5:
+                    out0 = (src5 >> bit_shift) | (src6 << inv_shift);
+                    out1 = (src6 >> bit_shift) | (src7 << inv_shift);
+                    out2 = (src7 >> bit_shift) | (fill << inv_shift);
+                    break;
+                case 6:
+                    out0 = (src6 >> bit_shift) | (src7 << inv_shift);
+                    out1 = (src7 >> bit_shift) | (fill << inv_shift);
+                    break;
+                default:
+                    out0 = (src7 >> bit_shift) | (fill << inv_shift);
+                    break;
+            }
+        }
+        else
+        {
+            switch (limb_shift)
+            {
+                case 0:
+                    return value;
+                case 1:
+                    out0 = src1;
+                    out1 = src2;
+                    out2 = src3;
+                    out3 = src4;
+                    out4 = src5;
+                    out5 = src6;
+                    out6 = src7;
+                    break;
+                case 2:
+                    out0 = src2;
+                    out1 = src3;
+                    out2 = src4;
+                    out3 = src5;
+                    out4 = src6;
+                    out5 = src7;
+                    break;
+                case 3:
+                    out0 = src3;
+                    out1 = src4;
+                    out2 = src5;
+                    out3 = src6;
+                    out4 = src7;
+                    break;
+                case 4:
+                    out0 = src4;
+                    out1 = src5;
+                    out2 = src6;
+                    out3 = src7;
+                    break;
+                case 5:
+                    out0 = src5;
+                    out1 = src6;
+                    out2 = src7;
+                    break;
+                case 6:
+                    out0 = src6;
+                    out1 = src7;
+                    break;
+                default:
+                    out0 = src7;
+                    break;
+            }
+        }
+        result.data_[0] = out0;
+        result.data_[1] = out1;
+        result.data_[2] = out2;
+        result.data_[3] = out3;
+        result.data_[4] = out4;
+        result.data_[5] = out5;
+        result.data_[6] = out6;
+        result.data_[7] = out7;
+        return result;
+    }
+
+    template <size_t L = limbs>
+    static GINT_CONSTEXPR14 typename std::enable_if<(L != 8), integer>::type
+    shift_right_value_by_size_fixed8(const integer &, size_t) noexcept
+    {
+        return integer();
+    }
+
     static GINT_CONSTEXPR14 GINT_FORCE_INLINE integer shift_right_value_by_size(const integer & value, size_t shift) noexcept
     {
         if (limbs == 16)
             return shift_right_value_by_size_fixed16(value, shift);
+        if (limbs == 8)
+            return shift_right_value_by_size_fixed8(value, shift);
 
         const bool is_signed_t = std::is_same<Signed, signed>::value;
         const bool neg = is_signed_t && (value.data_[limbs - 1] >> 63);


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：Int512 `^Shift/`
- 环境：Docker/GCC aarch64；本机 AppleClang 做宏关闭路径的对照检查

## 做了什么

- 将 AArch64/GCC 宽位左移/右移 fastpath 的启用阈值从 `L > 8` 放宽到 `L >= 8`，让 Int512/UInt512 也进入宽位 shift fastpath。
- 针对 8-limb 右移增加手写分派，避免 rebased 到 #112 后 Int512 右移仍落后 ClickHouse。
- 保持 16-limb Int1024 路径使用 #112 的专门化，不改变 1024 已验证实现。

## 结果

Docker/GCC aarch64：

- Int512 `Shift/RightVariable/gint_mean` 从 rebased #115 的 2.859204 ns 降至 1.769990 ns，+61.54%。
- Int512 当前三方对比：

| 用例 | gint | ClickHouse | Boost |
| --- | ---: | ---: | ---: |
| Int512 `Shift/LeftVariable` | 3.170082 ns | 3.440320 ns | 10.145303 ns |
| Int512 `Shift/RightVariable` | 1.769990 ns | 2.365278 ns | 4.839401 ns |

- Int1024 回归复测仍领先：

| 用例 | gint | ClickHouse | Boost |
| --- | ---: | ---: | ---: |
| Int1024 `Shift/LeftVariable` | 4.039140 ns | 4.929556 ns | 13.645552 ns |
| Int1024 `Shift/RightVariable` | 3.399242 ns | 3.785646 ns | 8.550202 ns |

结果文件：

- `runs/docker/int512_shift_manual8_512_shift_reps7.json`
- `runs/docker/int512_shift_fixed8_512_shift_reps7.json`
- `runs/docker/int512_shift_manual8_1024_shift_reps7.json`

## 验证

- `make TEST_BUILD_DIR=runs/local/build-int512-shift-fixed8 test`
- Docker/GCC `make TEST_BUILD_DIR=runs/docker/build-test-int512-shift-fixed8 test`
- `git diff --check`

## 风险

- 变更受现有 `GINT_ENABLE_AARCH64_GCC_WIDE_LEFT_SHIFT_UNSIGNED_FASTPATH` / `GINT_ENABLE_AARCH64_GCC_WIDE_RIGHT_SHIFT_UNSIGNED_FASTPATH` 宏保护，只影响 AArch64/GCC tuned path。
- 8-limb 手写路径只在 `L == 8` 时触发；16-limb Int1024 路径已单独复测。
