### PR TITLE
perf: speed up aarch64 gcc int128 large divisors

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -186,7 +186,7 @@
 #endif
 
 #ifndef GINT_ENABLE_AARCH64_TWO_LIMB_LARGE_DIVISOR_FASTPATH
-#    define GINT_ENABLE_AARCH64_TWO_LIMB_LARGE_DIVISOR_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#    define GINT_ENABLE_AARCH64_TWO_LIMB_LARGE_DIVISOR_FASTPATH (GINT_ARCH_AARCH64 && (GINT_GCC_TUNED_PATHS || GINT_CLANG_TUNED_PATHS))
 #endif
 
 #ifndef GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH
@@ -3812,7 +3812,11 @@ private:
 
         integer quotient;
         if (limbs == 2)
+#if GINT_ENABLE_AARCH64_TWO_LIMB_LARGE_DIVISOR_FASTPATH && GINT_GCC_TUNED_PATHS
+            quotient = div_128_native(lhs, divisor);
+#else
             quotient = div_128(lhs, divisor);
+#endif
         else if (divisor_limbs == 2)
             quotient = div_large_2(lhs, divisor);
         else if (divisor_limbs == 3)
@@ -3925,6 +3929,15 @@ private:
         }
 #endif
 
+        return div_128_native(lhs, rhs);
+    }
+
+    template <size_t L = limbs>
+    static typename std::enable_if<(L >= 2), integer>::type div_128_native(const integer & lhs, const integer & rhs) noexcept
+    {
+        integer result;
+        if (GINT_UNLIKELY((rhs.data_[1] | rhs.data_[0]) == 0))
+            return result;
         unsigned __int128 a = (static_cast<unsigned __int128>(lhs.data_[1]) << 64) | lhs.data_[0];
         unsigned __int128 b = (static_cast<unsigned __int128>(rhs.data_[1]) << 64) | rhs.data_[0];
         unsigned __int128 q = a / b;
@@ -3935,6 +3948,12 @@ private:
 
     template <size_t L = limbs>
     static typename std::enable_if<(L < 2), integer>::type div_128(const integer & lhs, const integer & rhs) noexcept
+    {
+        return div_128_native(lhs, rhs);
+    }
+
+    template <size_t L = limbs>
+    static typename std::enable_if<(L < 2), integer>::type div_128_native(const integer & lhs, const integer & rhs) noexcept
     {
         integer result;
         if (GINT_UNLIKELY(rhs.data_[0] == 0))


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：Int128 `^Div/`、`^Mod/`
- 环境：Docker/GCC，`gint:centos8`，`--benchmark_min_time=0.2s --benchmark_repetitions=7`

## 做了什么

- 在 AArch64/GCC 下启用已有的 two-limb large-divisor fast path。
- 拆出 `div_128_native`，让 AArch64/GCC 的 `%` 路径避免额外 fast-path 分支，防止 `Mod/SimilarMagnitude` 回退。
- Clang 的 `%` 路径保持原 `div_128` 行为。

## 结果

- `Div/LargeDivisor128/gint_mean`：9.004ns -> 3.317ns，约 2.71x。
- `Mod/SmallDivisor64/gint_mean`：7.754ns -> 7.591ns，同档略快。
- `Mod/SimilarMagnitude/gint_mean`：7.112ns -> 7.142ns，同档，无可归因回退。
- 结果文件：`runs/docker/int128_large_divisor_disabled_div_reps7.json`、`runs/docker/int128_large_divisor_native_rem_div_reps7.json`、`runs/docker/int128_large_divisor_disabled_mod_reps7.json`、`runs/docker/int128_large_divisor_native_rem_mod_reps7.json`

## 验证

- Docker/GCC：371/371 tests passed。
- 本机 AppleClang：371/371 tests passed。
- `git diff --check`

## 风险

- 影响范围集中在 AArch64/GCC 的 2-limb 大除数除法；`%` 路径已显式保留 native 商计算来规避分支回退。
