### PR TITLE
perf: speed up aarch64 gcc int128 left shifts

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -214,6 +214,10 @@
 #    define GINT_ENABLE_AARCH64_INT128_UNSIGNED_RIGHT_SHIFT_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
 #endif
 
+#ifndef GINT_ENABLE_AARCH64_GCC_INT128_LEFT_SHIFT_VALUE_FASTPATH
+#    define GINT_ENABLE_AARCH64_GCC_INT128_LEFT_SHIFT_VALUE_FASTPATH (GINT_ARCH_AARCH64 && GINT_GCC_TUNED_PATHS)
+#endif
+
 #ifndef GINT_ENABLE_AARCH64_GCC_WIDE_SHIFT_UNSIGNED_FASTPATH
 #    ifdef GINT_ENABLE_AARCH64_GCC_WIDE_LEFT_SHIFT_UNSIGNED_FASTPATH
 #        define GINT_ENABLE_AARCH64_GCC_WIDE_SHIFT_UNSIGNED_FASTPATH GINT_ENABLE_AARCH64_GCC_WIDE_LEFT_SHIFT_UNSIGNED_FASTPATH
@@ -1812,6 +1816,30 @@ public:
     }
 
 private:
+#if GINT_ENABLE_AARCH64_GCC_INT128_LEFT_SHIFT_VALUE_FASTPATH
+    template <size_t L = limbs>
+    static GINT_CONSTEXPR14 GINT_FORCE_INLINE typename std::enable_if<(L == 2), integer>::type
+    shift_left_int128_unsigned_value(const integer & lhs, unsigned n) noexcept
+    {
+        if (GINT_LIKELY(n < 128U))
+        {
+            using u128 = unsigned __int128;
+            const u128 raw = (static_cast<u128>(lhs.data_[1]) << 64) | lhs.data_[0];
+            const u128 shifted = raw << n;
+            integer result(uninitialized_tag{});
+            result.data_[0] = static_cast<limb_type>(shifted);
+            result.data_[1] = static_cast<limb_type>(shifted >> 64);
+            return result;
+        }
+
+        integer result(uninitialized_tag{});
+        result.data_[0] = 0;
+        result.data_[1] = 0;
+        return result;
+    }
+
+#endif
+
     template <size_t L = limbs>
     static GINT_CONSTEXPR14 GINT_FORCE_INLINE typename std::enable_if<(L == 2 && std::is_same<Signed, signed>::value), integer>::type
     shift_right_int128_unsigned_value(const integer & lhs, unsigned n) noexcept
@@ -2378,6 +2406,14 @@ public:
         lhs <<= n;
         return lhs;
     }
+
+#    if GINT_ENABLE_AARCH64_GCC_INT128_LEFT_SHIFT_VALUE_FASTPATH
+    template <size_t L = limbs, typename std::enable_if<(L == 2), int>::type = 0>
+    GINT_CONSTEXPR14 friend integer operator<<(const integer & lhs, unsigned n) noexcept
+    {
+        return shift_left_int128_unsigned_value(lhs, n);
+    }
+#    endif
 
 #    if GINT_ENABLE_AARCH64_GCC_WIDE_SHIFT_UNSIGNED_FASTPATH
     template <size_t L = limbs, typename std::enable_if<(L > 8), int>::type = 0>
@@ -4724,5 +4760,6 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_ENABLE_AARCH64_INT128_POSITIVE_LIMB_REM_FASTPATH
 #undef GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH
 #undef GINT_ENABLE_AARCH64_INT128_UNSIGNED_RIGHT_SHIFT_FASTPATH
+#undef GINT_ENABLE_AARCH64_GCC_INT128_LEFT_SHIFT_VALUE_FASTPATH
 #undef GINT_ENABLE_AARCH64_GCC_WIDE_SHIFT_UNSIGNED_FASTPATH
 #undef GINT_WIDE_SHIFT_INLINE

--- a/tests/shift_test.cpp
+++ b/tests/shift_test.cpp
@@ -202,6 +202,24 @@ TEST(WideIntegerShift, ExactBoundaryBitCounts)
     EXPECT_EQ(minus_one >> 128, S128(-1));
 }
 
+TEST(WideIntegerShift, UInt128UnsignedShiftAmountMatchesReference)
+{
+    using U128 = gint::integer<128, unsigned>;
+    using S128 = gint::integer<128, signed>;
+
+    U128 unsigned_value = patterned_value<U128>(0xbadc0ffee0ddf00dULL);
+    S128 signed_value = patterned_value<S128>(0x13579bdf2468ace0ULL);
+    TestAccess<S128>::limb(signed_value, S128::limbs - 1) |= uint64_t(1) << 63;
+
+    const unsigned shifts[] = {0, 1, 63, 64, 65, 73, 127, 128, 192};
+    for (std::size_t i = 0; i < sizeof(shifts) / sizeof(shifts[0]); ++i)
+    {
+        const unsigned shift = shifts[i];
+        EXPECT_EQ(unsigned_value << shift, reference_left_shift(unsigned_value, shift)) << "unsigned left shift " << shift;
+        EXPECT_EQ(signed_value << shift, reference_left_shift(signed_value, shift)) << "signed left shift " << shift;
+    }
+}
+
 TEST(WideIntegerShift, UInt256ExactWholeLimbRightShifts)
 {
     using U256 = gint::integer<256, unsigned>;


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`^Shift/`，重点是 `Shift/LeftVariable` 的 `BENCH_BITS=128`
- 环境：Docker/GCC，`gint:centos8`，GCC 8.5.0，`--benchmark_min_time=0.2s --benchmark_repetitions=7`

## 做了什么

- 为 AArch64/GCC 增加 `GINT_ENABLE_AARCH64_GCC_INT128_LEFT_SHIFT_VALUE_FASTPATH`。
- 对 2-limb `operator<<(const integer&, unsigned)` 使用 `unsigned __int128` 组装、左移并拆回 limb。
- 增加 128-bit `unsigned` shift amount 的左移边界测试，覆盖 signed/unsigned 结果。

## 结果

- `Shift/LeftVariable/gint_mean`：1.5726 ns -> 0.8563 ns，约 1.84x。
- `Shift/RightVariable/gint_mean`：1.1204 ns -> 1.1163 ns，无回退。
- 结果文件：
  - `runs/docker/int128_lshift_value_baseline_shift_reps7.json`
  - `runs/docker/int128_lshift_value_result_shift_reps7.json`

## 验证

- Docker/GCC：373/373 tests passed。
- 本机 AppleClang：373/373 tests passed。
- `git diff --check`

## 风险

- 该快路径默认只在 AArch64/GCC 启用；其它工具链保持原路径。
- 新重载只覆盖 `unsigned` shift amount；`int` 版本仍保留非正位移 no-op 语义。
