### PR TITLE
perf: speed up aarch64 gcc int128 division edges

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -194,7 +194,15 @@
 #endif
 
 #ifndef GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH
-#    define GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH (GINT_ARCH_AARCH64 && GINT_CLANG_TUNED_PATHS)
+#    define GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH (GINT_ARCH_AARCH64 && (GINT_CLANG_TUNED_PATHS || GINT_GCC_TUNED_PATHS))
+#endif
+
+#ifndef GINT_AARCH64_INT128_NEGATIVE_ZERO_DIV_ATTR
+#    if GINT_GCC_TUNED_PATHS
+#        define GINT_AARCH64_INT128_NEGATIVE_ZERO_DIV_ATTR GINT_NOINLINE
+#    else
+#        define GINT_AARCH64_INT128_NEGATIVE_ZERO_DIV_ATTR GINT_FORCE_INLINE
+#    endif
 #endif
 
 #ifndef GINT_ENABLE_AARCH64_TWO_LIMB_POSITIVE_POW2_DIV_FASTPATH
@@ -2491,6 +2499,11 @@ public:
         if (positive_single_limb_value(rhs, positive_limb_divisor))
         {
             GINT_DIVZERO_CHECK(positive_limb_divisor == 0);
+#    if GINT_ARCH_AARCH64 && GINT_GCC_TUNED_PATHS
+            if (limbs == 2 && std::is_same<Signed, signed>::value && positive_limb_divisor > 0xFFFFFFFFULL
+                && (positive_limb_divisor & (positive_limb_divisor - 1)) == 0)
+                return div_by_positive_power_of_two(lhs, static_cast<int>(__builtin_ctzll(positive_limb_divisor)));
+#    endif
             return div_by_positive_limb(lhs, positive_limb_divisor);
         }
 #elif GINT_ENABLE_AARCH64_LIMB2_POSITIVE_LIMB_DIV_FASTPATH
@@ -3680,7 +3693,7 @@ private:
     }
 
     template <size_t L = limbs>
-    static GINT_FORCE_INLINE typename std::enable_if<(L == 2), bool>::type
+    static GINT_AARCH64_INT128_NEGATIVE_ZERO_DIV_ATTR typename std::enable_if<(L == 2), bool>::type
     negative_negative_div_quotient_is_zero(const integer & lhs, const integer & rhs) noexcept
     {
 #if GINT_ARCH_AARCH64
@@ -4747,6 +4760,7 @@ struct formatter<gint::integer<Bits, Signed>>
 #undef GINT_ENABLE_X86_64_HW_SMALL_DIVMOD
 #undef GINT_ENABLE_AARCH64_TWO_LIMB_LARGE_DIVISOR_FASTPATH
 #undef GINT_ENABLE_AARCH64_INT128_NEGATIVE_ZERO_DIV_FASTPATH
+#undef GINT_AARCH64_INT128_NEGATIVE_ZERO_DIV_ATTR
 #undef GINT_ENABLE_AARCH64_TWO_LIMB_POSITIVE_POW2_DIV_FASTPATH
 #undef GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH
 #undef GINT_ENABLE_AARCH64_XOR16_UNROLL_FASTPATH


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：AArch64/GCC signed Int128 division edges；正式判定覆盖 `BENCH_BITS=128` full matrix，并对 `BENCH_BITS=256/512/1024` 的 `^(Div|Mod)/` 做防回退检查。
- 环境：Docker/GCC 8.5.0，`CMAKE_BUILD_TYPE=Release`，关联 issue #93。

## 做了什么

- 让 AArch64/GCC 启用 signed Int128 负数除法的 quotient-zero 快速检查，并在 GCC 下将该 helper 设为 noinline，降低热路径代码膨胀。
- 对 AArch64/GCC signed Int128 的正单 limb power-of-two 除数直接走 shift 除法路径，避开通用 small-divisor 除法。

## 结果

- `BENCH_BITS=128` full matrix 无 >=3% 回退。
- 主要收益（real_time mean）：
  - `Div/LargeDivisor128/gint`：8.3662 ns -> 1.2690 ns（-84.83%）
  - `Div/Pow2Divisor/gint`：3.1277 ns -> 1.8659 ns（-40.34%）
  - `Div/SmallDivisor32/gint`：3.9752 ns -> 3.4160 ns（-14.07%）
  - `Div/SmallDivisor64/gint`：6.9691 ns -> 6.6976 ns（-3.90%）
  - `Div/SimilarMagnitude2/gint`：5.1423 ns -> 4.9079 ns（-4.56%）
- `BENCH_BITS=256/512` 的 `^(Div|Mod)/` 无 >=3% 回退；`BENCH_BITS=1024` 的 `Div/` 反向重跑后无 >=3% 回退。
- 结果文件：
  - `runs/worktrees/pr117-baseline-clean/runs/docker/pr117_baseline_int128_full_reps9_m03.json`
  - `runs/docker/div_edge_candidate_narrow_int128_full_reps9_m03.json`
  - `runs/worktrees/pr117-baseline-clean/runs/docker/pr117_baseline_int1024_div_focus_reps9_m04_rerun.json`
  - `runs/docker/div_edge_candidate_narrow_int1024_div_focus_reps9_m04_rerun.json`

## 验证

- `git diff --check`
- Docker/GCC：`make TEST_BUILD_DIR=runs/docker/build-test test`（371/371 passed）
- 本机 AppleClang：`make TEST_BUILD_DIR=runs/local/build-test test`（371/371 passed）

## 风险

- 该路径受 `GINT_GCC_TUNED_PATHS` 与 `limbs == 2` 限制，主要影响 AArch64/GCC signed Int128 除法；非 GCC 和更宽位宽不应走新增分支。
