### PR TITLE
perf: speed up aarch64 gcc int128 positive limb division

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -3718,6 +3718,7 @@ private:
         return false;
     }
 
+    template <size_t L = limbs, typename std::enable_if<!(GINT_ARCH_AARCH64 && GINT_GCC_TUNED_PATHS && L == 2), int>::type = 0>
     static integer div_by_positive_limb(integer lhs, limb_type divisor) noexcept
     {
         integer result;
@@ -3735,6 +3736,42 @@ private:
         }
 
         lhs.div_mod_small(divisor, result);
+        return result;
+    }
+
+    template <size_t L = limbs, typename std::enable_if<(GINT_ARCH_AARCH64 && GINT_GCC_TUNED_PATHS && L == 2), int>::type = 0>
+    static integer div_by_positive_limb(integer lhs, limb_type divisor) noexcept
+    {
+        integer result;
+        if (std::is_same<Signed, signed>::value && (lhs.data_[limbs - 1] >> 63))
+        {
+#if GINT_ENABLE_AARCH64_INT128_SIGNED_LIMB_DIV_FASTPATH
+            if (GINT_UNLIKELY(divisor > 0xFFFFFFFFULL && (divisor & (divisor - 1)) != 0)
+                && div_signed_int128_by_positive_limb(lhs, divisor, result))
+                return result;
+#endif
+            negate_for_division(lhs);
+            lhs.div_mod_small(divisor, result);
+            negate_for_division(result);
+            return result;
+        }
+
+        if (divisor > 0xFFFFFFFFULL && (divisor & (divisor - 1)) != 0)
+            return div_unsigned_int128_by_positive_limb(lhs, divisor);
+
+        lhs.div_mod_small(divisor, result);
+        return result;
+    }
+
+    template <size_t L = limbs, typename std::enable_if<(L == 2), int>::type = 0>
+    static GINT_FORCE_INLINE integer div_unsigned_int128_by_positive_limb(const integer & lhs, limb_type divisor) noexcept
+    {
+        using u128 = unsigned __int128;
+        const u128 lhs_raw = (static_cast<u128>(lhs.data_[1]) << 64) | lhs.data_[0];
+        const u128 quotient = lhs_raw / divisor;
+        integer result;
+        result.data_[0] = static_cast<limb_type>(quotient);
+        result.data_[1] = static_cast<limb_type>(quotient >> 64);
         return result;
     }
 


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`BENCH_BITS=128` 的 `^Div/SmallDivisor64/`；回归检查覆盖 `BENCH_BITS=128` full matrix 以及 `BENCH_BITS=256/512/1024` 的 `^(Div|Mod)/`
- 环境：Docker/GCC `gint:centos8`，GCC 8.5.0，`CMAKE_BUILD_TYPE` 未显式设置

## 做了什么

- 为 AArch64/GCC 下的 two-limb `integer` 增加专用 `div_by_positive_limb` 重载。
- 当正数 `Int128`/`UInt128` 除以非 2 的幂的 64-bit 单 limb 正除数时，直接使用 native `unsigned __int128 / uint64_t` 生成商。
- 其它位宽继续实例化原有 `div_by_positive_limb` 函数体，避免宽位宽代码布局受到 fastpath 扰动。

## 结果

- `Int128` full matrix：`Div/SmallDivisor64/gint_mean` 从 6.697ns 降到 4.843ns，提升 27.69%；无 >3% 回退。
- 三方目标对比：`Div/SmallDivisor64/gint_mean` 从 6.974ns 降到 5.379ns，提升 22.88%；当前 gint 比 ClickHouse 快 1.53x，仍比 Boost 慢 1.61x。
- 宽位宽回归：`256/512/1024` 的 `Div/Mod` 全组均无 >3% 回退；最差分别为 2.75%、1.07%、2.71%。
- 结果文件：
  - `runs/docker/sfinae_unsigned_limb_div_candidate_int128_full_reps9_m03.json`
  - `runs/docker/sfinae_unsigned_limb_div_candidate_int128_compare_div_small64_reps9_m03.json`
  - `runs/docker/sfinae_unsigned_limb_div_candidate_int256_divmod_reps7_m02.json`
  - `runs/docker/sfinae_unsigned_limb_div_candidate_int512_divmod_reps7_m02.json`
  - `runs/docker/sfinae_unsigned_limb_div_candidate_int1024_divmod_reps7_m02.json`

## 验证

- `git diff --check`
- `make TEST_BUILD_DIR=runs/local/build-test test`
- `docker run --rm -t -v "$PWD":/work -w /work gint:centos8 make TEST_BUILD_DIR=runs/docker/build-test test`

## 风险

- 该 fastpath 只覆盖非负 two-limb 值除以非 2 的幂的 64-bit 正单 limb 除数；负数路径和宽位宽路径保持原实现。
