### PR TITLE
feat: add validation environment bootstrap

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -6,12 +6,14 @@
 
 ## 环境口径
 
-- 本机（local）：指宿主机 macOS + AppleClang 工具链，构建与输出目录使用 `runs/local/`。
-- Docker/GCC：指 `gint:centos8` 容器内的 CentOS 8 + GCC/g++ 工具链，构建与输出目录使用 `runs/docker/`。Dockerfile 也安装 `clang`/`clangd` 作为开发辅助工具，但未显式设置 `CC`/`CXX` 时，CMake 默认使用 GCC/g++。
-- 两套结果用于验证不同 OS/编译器组合；性能报告应分别呈现，不直接混合横向比较。
+- 默认本机（local）：指当前 macOS + AppleClang 工具链，构建与输出目录使用 `runs/local/`。
+- 其他环境或编译器：使用独立 `runs/<scope>/` 和独立 `BENCH_BUILD_DIR`，例如本机 GCC、Linux GCC、Linux Clang 等。
+- 仓库内命令只假定已经位于当前执行环境；具体在哪里运行由外部编排决定。
+- 不同架构、OS、编译器结果应分别呈现，不直接混合横向比较。
+- 可复现验证环境的初始化方式见 [验证环境固化](VALIDATION_ENVIRONMENTS.md)。该文档只固化当前环境依赖，不固定具体测试项目、过滤器或位宽。
 
-## 当前本机 AppleClang 样本
-- 平台：Apple M4 Pro，macOS 26.4.1，arm64
+## 本机 AppleClang 样本（历史示例）
+- 采集平台：Apple M4 Pro，macOS 26.4.1，arm64
 - 核心数：12
 - 工具链：AppleClang 21.0.0，Google Benchmark v1.9.5
 - 编译：Release（`-O3 -DNDEBUG`）
@@ -20,7 +22,7 @@
 
 ## 通用提示
 - 本机 AppleClang 口径下，Makefile 默认构建目录位于 `runs/local/`：测试 `runs/local/build`，基准 `runs/local/build-bench`，覆盖率 `runs/local/build-coverage`。
-- Docker/GCC 验证需显式通过 `docker run ... gint:centos8 make BENCH_BUILD_DIR=runs/docker/build-bench ...` 执行，产物放在 `runs/docker/`。
+- 非默认环境验证需显式指定独立 `BENCH_BUILD_DIR`，产物放在对应 `runs/<scope>/`。
 - 最短运行时间：建议加入 `--benchmark_min_time=0.2s`（单位必须为秒）。
 - 过滤子集：可用 `--benchmark_filter`（示例：`--benchmark_filter=^Div/SmallDivisor64/`）。
 - 完整矩阵：使用 `bench-full` 或 `bench-compare-full`，等价于给可执行传入 `--gint_full`。
@@ -34,7 +36,7 @@
 ### 用法
 - 本机 AppleClang 标准矩阵：`make bench BENCH_ARGS="--benchmark_min_time=0.2s"`
 - 本机 AppleClang 完整矩阵：`make bench-full BENCH_ARGS="--benchmark_min_time=0.2s"`
-- Docker/GCC 完整矩阵：`docker run --rm -t -v "$PWD":/work -w /work gint:centos8 make BENCH_BUILD_DIR=runs/docker/build-bench bench-full BENCH_ARGS="--benchmark_min_time=0.2s"`
+- 其他环境完整矩阵：`make BENCH_BUILD_DIR=runs/<scope>/build-bench bench-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 - 本机直接运行：`runs/local/build-bench/perf_benchmark_int256 --benchmark_min_time=0.2s`
 - 其他位宽：`make BENCH_BITS=512 bench-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 
@@ -50,7 +52,7 @@
 ### 用法
 - 本机 AppleClang 标准矩阵：`make bench-compare BENCH_ARGS="--benchmark_min_time=0.2s"`
 - 本机 AppleClang 完整矩阵：`make bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`
-- Docker/GCC 完整矩阵：`docker run --rm -t -v "$PWD":/work -w /work gint:centos8 make BENCH_BUILD_DIR=runs/docker/build-bench bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`
+- 其他环境完整矩阵：`make BENCH_BUILD_DIR=runs/<scope>/build-bench bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 - 本机直接运行：`runs/local/build-bench/perf_compare_int256 --gint_full --benchmark_min_time=0.2s`
 - 其他位宽：`make BENCH_BITS=1024 bench-compare-full BENCH_ARGS="--benchmark_min_time=0.2s"`
 

--- a/docs/VALIDATION_ENVIRONMENTS.md
+++ b/docs/VALIDATION_ENVIRONMENTS.md
@@ -1,0 +1,121 @@
+# 当前环境验证固化
+
+本文只固化“当前执行环境”里的依赖与目录约定，不规定命令应该在哪里执行。外部编排负责选择运行位置；进入目标环境后，仓库内脚本和 `Makefile` 只负责在当前环境跑测试。
+
+本文也不固定具体测试项目。单元测试、基准测试、对比测试、过滤器、位宽和输出文件都由调用方按任务传入。
+
+## 边界
+
+- 仓库内：准备当前环境依赖、生成当前环境的 compiler env、执行调用方指定的 test/benchmark 目标。
+- 仓库外：决定执行位置、生命周期管理、代码同步和结果回收方式。
+- 报告时：不同架构、OS、编译器结果应分开呈现，不直接混合成一个横向排名。
+
+## 推荐环境形态
+
+推荐外部编排覆盖这些环境形态，但仓库命令只面向已经进入的当前环境：
+
+| 形态 | 主要用途 |
+| --- | --- |
+| macOS arm64 + AppleClang | 快速正确性、真实 macOS 集成、本地 arm 编译器覆盖 |
+| Linux arm64 + GCC/Clang | 可重复 arm 编译器覆盖 |
+| Linux x86_64 + GCC/Clang | 合并前关键性能确认，覆盖 x86 代码生成 |
+
+## 目录约定
+
+所有环境构建、依赖源码、依赖安装、benchmark JSON/CSV 和临时输出都放在 `runs/` 下：
+
+- 调用方通过 `--scope <name>` 或 `*_BUILD_DIR` 决定当前环境输出 scope；
+- 常用 scope 示例：`local`、`linux-arm64`、`linux-x86_64`、`ci`；
+- scope 只是目录命名，不表达机器位置。
+
+环境脚本会在对应 scope 下生成：
+
+- `runs/<scope>/deps/`：固定版本依赖源码、构建目录和安装目录
+- `runs/<scope>/env/`：可 `source` 的编译器环境文件
+
+env 文件名由编译器完整路径安全化生成。例如 `/usr/bin/g++` 对应 `usr_bin_gxx.env`；这样同一环境里多个 basename 相同但路径不同的编译器不会互相覆盖。
+env 文件还会导出同名的 `GINT_COMPILER_ID`，用于为该编译器选择独立 build 目录。
+
+## 当前环境初始化
+
+进入当前环境后运行：
+
+```bash
+SCOPE=linux-x86_64
+scripts/bootstrap-validation-env.sh --scope "${SCOPE}"
+```
+
+脚本做三件事：
+
+- 在 Ubuntu/Debian 上安装基础包，其他系统可用 `--skip-packages` 跳过包安装；
+- 在 `runs/<scope>/deps/` 下为每个编译器构建 Release 版 Google Benchmark；
+- 在 `runs/<scope>/env/` 下生成 env 文件。
+
+脚本不会运行任何项目测试或 benchmark。
+
+### Ubuntu/Debian 包
+
+当前环境是 Ubuntu/Debian 时，脚本会安装以下包：
+
+```text
+build-essential
+ca-certificates
+clang
+cmake
+curl
+git
+libboost-dev
+libfmt-dev
+libgtest-dev
+ninja-build
+pkg-config
+rsync
+tar
+```
+
+不要依赖发行版 `libbenchmark-dev` 做性能结论；本项目用脚本在 `runs/` 下构建固定版本 Release `google-benchmark`，避免发行版包构建类型污染结果。
+
+非 Ubuntu/Debian 且依赖已安装的环境可显式跳过包安装，只构建当前编译器对应的 `google-benchmark`：
+
+```bash
+SCOPE=current-gcc
+scripts/bootstrap-validation-env.sh --scope "${SCOPE}" --skip-packages --compiler g++
+```
+
+### 使用生成的编译器环境
+
+```bash
+SCOPE=linux-x86_64
+source "runs/${SCOPE}/env/usr_bin_gxx.env"
+cmake -S . -B "runs/${SCOPE}/build-${GINT_COMPILER_ID}-custom" \
+  -DGINT_BUILD_TESTS=ON \
+  -DGINT_BUILD_BENCHMARKS=OFF \
+  -DCMAKE_CXX_COMPILER="$CMAKE_CXX_COMPILER"
+```
+
+Clang 环境通常使用对应路径的安全化文件名，例如 `usr_bin_clangxx.env`。脚本结束时会打印当前环境可直接使用的 `source` 示例。
+
+## 测试项目由任务决定
+
+环境固化不绑定测试目标。调用方可以选择：
+
+- `ctest`；
+- `make bench` / `bench-full`；
+- `make bench-compare` / `bench-compare-full`；
+- 直接运行某个位宽的 benchmark 可执行；
+- 任意 `BENCH_ARGS`、`BENCH_BITS`、`--benchmark_filter`、`--benchmark_repetitions` 和 `--benchmark_out`。
+
+示例只表达调用形状，不代表固定矩阵：
+
+```bash
+SCOPE=linux-x86_64
+source "runs/${SCOPE}/env/usr_bin_gxx.env"
+make BENCH_BUILD_DIR="runs/${SCOPE}/build-bench-${GINT_COMPILER_ID}" \
+  BENCH_BITS=256 \
+  bench-full \
+  BENCH_ARGS="<caller-provided benchmark args>"
+```
+
+同一个 `SCOPE` 下切换编译器时必须使用不同 `BENCH_BUILD_DIR` 或清理旧构建目录；否则 CMake cache 会继续使用第一次配置时的编译器。
+
+严格性能回归判断必须在同一环境、同一编译器、同一源码口径、同一参数下建立 baseline 和 result；x86 有噪声时需要重复运行。

--- a/scripts/bootstrap-validation-env.sh
+++ b/scripts/bootstrap-validation-env.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/bootstrap-validation-env.sh [options]
+
+Prepare the current validation environment under runs/<scope>/ without running
+project tests or benchmarks.
+
+Options:
+  --scope <name>              Output scope under runs/ (default: linux)
+  --compiler <cxx>            C++ compiler to prepare; repeatable
+                              (default: g++ and clang++ when available)
+  --benchmark-version <ver>   Google Benchmark version, with or without v
+                              prefix (default: 1.9.5)
+  --skip-packages             Do not install OS packages
+  --jobs <n>                  Build parallelism (default: detected CPU count)
+  -h, --help                  Show this help
+
+Generated files:
+  runs/<scope>/env/<compiler-path-id>.env
+
+The generated env files set CMAKE_CXX_COMPILER and prepend the matching
+Release-built Google Benchmark prefix to CMAKE_PREFIX_PATH. Callers choose
+their own CMake targets, make targets, BENCH_ARGS, filters, and output files.
+EOF
+}
+
+scope="linux"
+benchmark_version="1.9.5"
+skip_packages=0
+jobs=""
+declare -a requested_compilers=()
+
+while (($#)); do
+    case "$1" in
+        --scope)
+            scope="${2:?missing value for --scope}"
+            shift 2
+            ;;
+        --compiler)
+            requested_compilers+=("${2:?missing value for --compiler}")
+            shift 2
+            ;;
+        --benchmark-version)
+            benchmark_version="${2:?missing value for --benchmark-version}"
+            shift 2
+            ;;
+        --skip-packages)
+            skip_packages=1
+            shift
+            ;;
+        --jobs)
+            jobs="${2:?missing value for --jobs}"
+            shift 2
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ "$scope" == /* || "$scope" == *"/"* || "$scope" == *".."* ]]; then
+    echo "error: --scope must be a simple runs/ scope name" >&2
+    exit 2
+fi
+
+if [[ -z "$jobs" ]]; then
+    if command -v nproc >/dev/null 2>&1; then
+        jobs="$(nproc)"
+    elif command -v getconf >/dev/null 2>&1; then
+        jobs="$(getconf _NPROCESSORS_ONLN)"
+    else
+        jobs="1"
+    fi
+fi
+
+version="${benchmark_version#v}"
+tag="v${version}"
+run_root="runs/${scope}"
+deps_root="${run_root}/deps"
+src_root="${deps_root}/src"
+env_root="${run_root}/env"
+
+mkdir -p "$src_root" "$env_root"
+
+apt_get() {
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        env DEBIAN_FRONTEND=noninteractive apt-get "$@"
+        return
+    fi
+
+    if command -v sudo >/dev/null 2>&1; then
+        sudo env DEBIAN_FRONTEND=noninteractive apt-get "$@"
+        return
+    fi
+
+    echo "error: package installation needs root or sudo; use --skip-packages to skip it" >&2
+    exit 2
+}
+
+install_packages() {
+    if ((skip_packages)); then
+        echo "[env] skipping package installation"
+        return
+    fi
+
+    if command -v apt-get >/dev/null 2>&1; then
+        echo "[env] installing Ubuntu/Debian validation packages"
+        apt_get update
+        apt_get install -y \
+            build-essential \
+            ca-certificates \
+            clang \
+            cmake \
+            curl \
+            git \
+            libboost-dev \
+            libfmt-dev \
+            libgtest-dev \
+            ninja-build \
+            pkg-config \
+            rsync \
+            tar
+        return
+    fi
+
+    echo "[env] apt-get not found; assuming compiler, CMake, fmt, GTest, and Boost are already installed"
+}
+
+resolve_compilers() {
+    local -a input=("$@")
+    local -a resolved=()
+    local candidate path
+
+    if ((${#input[@]} == 0)); then
+        input=(g++ clang++)
+    fi
+
+    for candidate in "${input[@]}"; do
+        if [[ "$candidate" == */* && -x "$candidate" ]]; then
+            path="$(cd "$(dirname "$candidate")" && pwd -P)/$(basename "$candidate")"
+            resolved+=("$path")
+        elif path="$(command -v "$candidate" 2>/dev/null)"; then
+            resolved+=("$path")
+        elif ((${#requested_compilers[@]} > 0)); then
+            echo "error: compiler not found: $candidate" >&2
+            exit 2
+        else
+            echo "[env] compiler not found, skipping: $candidate" >&2
+        fi
+    done
+
+    if ((${#resolved[@]} == 0)); then
+        echo "error: no C++ compilers found" >&2
+        exit 2
+    fi
+
+    printf '%s\n' "${resolved[@]}"
+}
+
+compiler_id() {
+    local id path
+    path="$1"
+    if [[ "$path" != /* ]]; then
+        path="$(command -v "$path")"
+    fi
+
+    id="${path#/}"
+    id="${id//++/xx}"
+    id="${id//\//_}"
+    id="${id//[^A-Za-z0-9._-]/_}"
+    printf '%s\n' "$id"
+}
+
+shell_quote() {
+    printf '%q' "$1"
+}
+
+download_benchmark_archive() {
+    local archive="$1"
+    local tmp_archive="${archive}.tmp.$$"
+
+    rm -f "$tmp_archive"
+    if ! curl --fail --location --retry 3 --retry-delay 2 --connect-timeout 20 --max-time 300 \
+        "https://github.com/google/benchmark/archive/refs/tags/${tag}.tar.gz" -o "$tmp_archive"; then
+        rm -f "$tmp_archive"
+        echo "error: failed to download Google Benchmark ${tag}" >&2
+        return 1
+    fi
+
+    mv "$tmp_archive" "$archive"
+}
+
+fetch_benchmark() {
+    local archive="${src_root}/benchmark-${version}.tar.gz"
+    local src_dir="${src_root}/benchmark-${version}"
+
+    if [[ ! -d "$src_dir" ]]; then
+        if [[ ! -f "$archive" ]]; then
+            echo "[env] downloading Google Benchmark ${tag}" >&2
+            download_benchmark_archive "$archive" || return 1
+        fi
+        rm -rf "$src_dir"
+        if ! tar -xzf "$archive" -C "$src_root"; then
+            rm -rf "$src_dir"
+            rm -f "$archive"
+            echo "error: failed to extract Google Benchmark archive; removed ${archive}" >&2
+            return 1
+        fi
+        if [[ ! -d "$src_dir" ]]; then
+            echo "error: Google Benchmark archive did not extract to ${src_dir}" >&2
+            rm -f "$archive"
+            return 1
+        fi
+    fi
+
+    printf '%s\n' "$src_dir"
+}
+
+build_benchmark_for_compiler() {
+    local compiler="$1"
+    local src_dir="$2"
+    local id build_dir install_dir env_file
+
+    id="$(compiler_id "$compiler")"
+    build_dir="${deps_root}/google-benchmark-${version}/${id}/build"
+    install_dir="${deps_root}/google-benchmark-${version}/${id}/install"
+    env_file="${env_root}/${id}.env"
+
+    echo "[env] building Google Benchmark ${tag} for ${compiler} -> ${install_dir}"
+    cmake -S "$src_dir" -B "$build_dir" \
+        -DCMAKE_CXX_COMPILER="$compiler" \
+        -DCMAKE_INSTALL_PREFIX="$PWD/$install_dir" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBENCHMARK_ENABLE_TESTING=OFF \
+        -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+        -DBENCHMARK_ENABLE_LIBPFM=OFF
+    cmake --build "$build_dir" --parallel "$jobs"
+    cmake --install "$build_dir"
+
+    {
+        echo "# Generated by scripts/bootstrap-validation-env.sh"
+        echo "# Source this before configuring a build with this compiler."
+        printf 'export GINT_VALIDATION_SCOPE=%s\n' "$(shell_quote "$scope")"
+        printf 'export GINT_COMPILER_ID=%s\n' "$(shell_quote "$id")"
+        printf 'export CMAKE_CXX_COMPILER=%s\n' "$(shell_quote "$compiler")"
+        printf 'export CXX=%s\n' "$(shell_quote "$compiler")"
+        printf 'export GINT_BENCHMARK_PREFIX=%s\n' "$(shell_quote "$PWD/$install_dir")"
+        cat <<'EOF'
+if [ -n "${CMAKE_PREFIX_PATH:-}" ]; then
+    export CMAKE_PREFIX_PATH="${GINT_BENCHMARK_PREFIX}:${CMAKE_PREFIX_PATH}"
+else
+    export CMAKE_PREFIX_PATH="${GINT_BENCHMARK_PREFIX}"
+fi
+EOF
+    } >"$env_file"
+
+    echo "[env] wrote ${env_file}"
+}
+
+install_packages
+compilers=()
+compiler_output=""
+if ! compiler_output="$(resolve_compilers "${requested_compilers[@]}")"; then
+    echo "error: failed to resolve requested compilers" >&2
+    exit 2
+fi
+while IFS= read -r compiler_path; do
+    [[ -n "$compiler_path" ]] || continue
+    compilers+=("$compiler_path")
+done <<<"$compiler_output"
+if ! benchmark_src="$(fetch_benchmark)"; then
+    echo "error: failed to prepare Google Benchmark ${tag}" >&2
+    exit 2
+fi
+
+for compiler in "${compilers[@]}"; do
+    build_benchmark_for_compiler "$compiler" "$benchmark_src"
+done
+
+cat <<EOF
+[env] done
+
+Next step examples (choose your own targets and BENCH_ARGS):
+  source ${env_root}/$(compiler_id "${compilers[0]}").env
+  cmake -S . -B ${run_root}/build-\${GINT_COMPILER_ID}-<name> -DGINT_BUILD_TESTS=ON -DGINT_BUILD_BENCHMARKS=OFF -DCMAKE_CXX_COMPILER="\$CMAKE_CXX_COMPILER"
+  cmake -S . -B ${run_root}/build-bench-\${GINT_COMPILER_ID}-<name> -DGINT_BUILD_TESTS=OFF -DGINT_BUILD_BENCHMARKS=ON -DCMAKE_PREFIX_PATH="\$CMAKE_PREFIX_PATH" -DCMAKE_CXX_COMPILER="\$CMAKE_CXX_COMPILER"
+EOF


### PR DESCRIPTION
## 概述

- 固化“当前执行环境”里的验证依赖初始化流程，同时保持具体测试项目、过滤器、位宽和输出文件由调用方按任务决定。

## 做了什么

- 新增 `scripts/bootstrap-validation-env.sh`，按 scope 在 `runs/` 下准备固定版本 Release `google-benchmark`，并为每个编译器生成可 `source` 的 env 文件。
- 新增 `docs/VALIDATION_ENVIRONMENTS.md`，说明仓库内外边界、推荐环境形态、目录约定、依赖包和调用方式。
- 更新 `docs/BENCHMARKS.md`，移除固定 Docker/GCC 执行说明，改为当前环境内运行和独立 `runs/<scope>/` 口径。
- 处理 Codex review：编译器 env/build/install id 改为基于完整编译器路径的安全化形式，避免多个 basename 相同的编译器互相覆盖。
- 处理 Codex review：`google-benchmark` archive 改为临时文件下载，下载失败清理临时文件，解压失败删除损坏 archive 并退出。
- 处理 Codex review：显式编译器解析失败会在主流程中立即失败，避免 process substitution 吞掉错误。
- 处理 Codex review：解压失败时同时清理损坏 archive 和可能已部分展开的源码目录。
- 处理 Codex review：env 文件导出 `GINT_COMPILER_ID`，示例和文档使用按编译器隔离的 build 目录，避免 CMake cache 复用错误编译器。

## API / 行为

- 只新增验证环境 helper 和文档；现有 `Makefile` 目标、benchmark 目标、测试目标和库代码行为不变。
- 仓库脚本不决定在哪里运行测试，也不绑定具体 benchmark 矩阵。

## 验证

- `git diff --check`
- `bash -n scripts/bootstrap-validation-env.sh`
- `scripts/bootstrap-validation-env.sh --help`
- `scripts/bootstrap-validation-env.sh --scope pr-validation-smoke --skip-packages --compiler clang++ --jobs 8`
- 同 basename 编译器路径回归验证：用两个不同目录下名为 `g++` 的编译器路径运行 bootstrap，确认生成两个独立 env 和 install 目录。
- 损坏 archive 回归验证：预置无效或截断的 `benchmark-1.9.5.tar.gz` 后运行 bootstrap，确认脚本失败退出并删除损坏 archive 及部分源码目录。
- 缺失编译器回归验证：同时传入有效 `clang++` 和不存在的编译器路径，确认脚本在 benchmark 下载前失败退出。
- 编译器隔离 build 目录验证：source 生成的 env 后确认 `GINT_COMPILER_ID`，并使用带该 id 的 build 目录配置/构建 benchmark 目标，`--benchmark_list_tests` 正常列出用例。
- 使用生成的 env 配置并构建 `perf_benchmark_int256`，`--benchmark_list_tests` 正常列出用例。
- 构建完整测试目标后运行 `ctest`：383 个测试全部通过。
- 本地容器架构检查：`gint:centos8` 镜像为 `os=linux arch=arm64`，容器内 `uname -m` 为 `aarch64`，`g++ -dumpmachine` 为 `aarch64-redhat-linux`；旧的 `gint:centos8-amd64` 是单独标签，未作为当前默认本地验证路径。

## 兼容性与风险

- 该 PR 不改库实现，不影响性能路径。
- 初始化脚本会下载并构建指定版本 `google-benchmark`；离线环境需要提前准备依赖或复用已有 `runs/` 产物。
- Ubuntu/Debian 包安装需要 root 或 sudo；其他环境可用 `--skip-packages`。
