### PR TITLE
perf: speed up wide Clang modulo

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -2968,6 +2968,17 @@ public:
             return rem_unsigned_magnitude(lhs, rhs);
         }
 #else
+#    if GINT_CLANG_TUNED_PATHS
+        if (limbs >= 8)
+        {
+            if (std::is_same<Signed, signed>::value)
+            {
+                const bool rhs_neg = rhs.data_[limbs - 1] >> 63;
+                return rem_signed_magnitude(lhs, rhs, rhs_neg);
+            }
+            return rem_unsigned_magnitude_with_large_direct(lhs, rhs);
+        }
+#    endif
         integer q = lhs / rhs;
         q *= rhs;
         lhs -= q;
@@ -4137,6 +4148,8 @@ private:
 
 #if GINT_DETAIL_AARCH64_GCC
         Unsigned rem_mag = Unsigned::rem_unsigned_magnitude_with_large_direct(lhs_mag, rhs_mag);
+#elif GINT_CLANG_TUNED_PATHS
+        Unsigned rem_mag = rem_signed_magnitude_unsigned(lhs_mag, rhs_mag);
 #else
         Unsigned rem_mag = Unsigned::rem_unsigned_magnitude(lhs_mag, rhs_mag);
 #endif
@@ -4147,6 +4160,22 @@ private:
             negate_for_division(result);
         return result;
     }
+
+#if GINT_CLANG_TUNED_PATHS
+    template <size_t L = limbs>
+    static GINT_FORCE_INLINE typename std::enable_if<(L >= 8), integer<Bits, unsigned>>::type
+    rem_signed_magnitude_unsigned(const integer<Bits, unsigned> & lhs_mag, const integer<Bits, unsigned> & rhs_mag) noexcept
+    {
+        return integer<Bits, unsigned>::rem_unsigned_magnitude_with_large_direct(lhs_mag, rhs_mag);
+    }
+
+    template <size_t L = limbs>
+    static GINT_FORCE_INLINE typename std::enable_if<(L < 8), integer<Bits, unsigned>>::type
+    rem_signed_magnitude_unsigned(const integer<Bits, unsigned> & lhs_mag, const integer<Bits, unsigned> & rhs_mag) noexcept
+    {
+        return integer<Bits, unsigned>::rem_unsigned_magnitude(lhs_mag, rhs_mag);
+    }
+#endif
 
     static integer rem_unsigned_magnitude(const integer & lhs, const integer & divisor) noexcept
     {
@@ -4209,8 +4238,9 @@ private:
 
     static integer rem_unsigned_magnitude_with_large_direct(const integer & lhs, const integer & divisor) noexcept
     {
-#if GINT_DETAIL_AARCH64_GCC
-        if (limbs >= 4 && GINT_UNLIKELY((divisor.data_[limbs - 1] | divisor.data_[limbs - 2]) != 0))
+#if GINT_DETAIL_AARCH64_GCC || GINT_CLANG_TUNED_PATHS
+        if (((GINT_DETAIL_AARCH64_GCC && limbs >= 4) || (GINT_CLANG_TUNED_PATHS && limbs >= 8))
+            && GINT_UNLIKELY((divisor.data_[limbs - 1] | divisor.data_[limbs - 2]) != 0))
         {
             const size_t divisor_limbs = used_limbs(divisor);
             int pow_bit;


### PR DESCRIPTION
## 目标

- 用例 / 过滤器：`Mod/SimilarMagnitude` 为主，完整矩阵覆盖 `bench-compare-full` 与 `BENCH_BITS=128,256,512,1024`
- 环境：本机 arm64 AppleClang、arm64 Linux GCC/Clang、x86_64 Linux GCC/Clang

## 做了什么

- 让 Clang 512/1024 位 `%` 在大除数同量级场景直接复用 large remainder 路径，避免先求完整 quotient 再乘回。
- signed modulo 通过 unsigned magnitude 复用相同边界；GCC 既有 tuned path 保持原样，Clang 128/256 继续走旧路径。

## 结果

- `Mod/SimilarMagnitude` 512/1024 主要改善：AppleClang 约 11.1% / 25.1%，arm64 Linux Clang 约 15.8% / 26.6%，x86_64 Linux Clang 约 7.7% / 39.8%。
- 全矩阵旧版对比新版：48/460 项快于 3%，362/460 项在 3% 内；单次超过 3% 的 50 个疑似回退逐项重复复测后确认回退为 0。
- 新版相对 ClickHouse/Boost：345/460 项最快，15/460 项落后最快实现不超过 3%，100/460 项仍落后超过 3%。

## 验证

- `clang-format`
- `git diff --check`
- 本机 AppleClang 单元测试：383/383 通过
- arm64 Linux GCC/Clang 单元测试：383/383 通过
- x86_64 Linux GCC/Clang 单元测试：383/383 通过
- 本机 AppleClang、arm64 Linux GCC/Clang、x86_64 Linux GCC/Clang 完整 `bench-compare-full` 矩阵；所有疑似回退按同口径重复复测

## 风险

- 改动集中在 Clang 512/1024 位大除数 modulo 路径，依赖现有 large remainder 实现的严格位宽语义。
- 128/256 位与 GCC tuned path 保持既有边界，降低对邻近 Add/Sub/Shift/Div 路径的影响。