### PR TITLE
fix: correct long double comparisons and mulhi

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -329,6 +329,23 @@ inline unsigned __int128 mulhi_u128(unsigned __int128 a, unsigned __int128 b) no
     const unsigned __int128 t1 = a0 * b1;
     const unsigned __int128 t2 = a1 * b0;
     const unsigned __int128 t3 = a1 * b1;
+    const unsigned __int128 mid = (t0 >> 64) + static_cast<uint64_t>(t1) + static_cast<uint64_t>(t2);
+    return t3 + (t1 >> 64) + (t2 >> 64) + (mid >> 64);
+}
+
+// Fast high-half multiply for division reciprocal paths where the middle
+// accumulation is proven not to wrap modulo 2^128. Use mulhi_u128 for the
+// general 128x128->256 high-half contract.
+inline unsigned __int128 mulhi_u128_no_middle_wrap(unsigned __int128 a, unsigned __int128 b) noexcept
+{
+    const unsigned __int128 a0 = static_cast<uint64_t>(a);
+    const unsigned __int128 a1 = a >> 64;
+    const unsigned __int128 b0 = static_cast<uint64_t>(b);
+    const unsigned __int128 b1 = b >> 64;
+    const unsigned __int128 t0 = a0 * b0;
+    const unsigned __int128 t1 = a0 * b1;
+    const unsigned __int128 t2 = a1 * b0;
+    const unsigned __int128 t3 = a1 * b1;
     const unsigned __int128 s = (t0 >> 64) + t1 + t2;
     return t3 + (s >> 64);
 }
@@ -3017,15 +3034,23 @@ public:
         const int p = std::numeric_limits<T>::digits;
         int shift = hb - (p - 1);
         integer scaled = lhs_abs;
-        if (shift > 0)
-            scaled >>= shift;
-        else if (shift < 0)
-            scaled <<= -shift;
         unsigned __int128 sigA = 0;
         if (limbs >= 2)
-            sigA = (static_cast<unsigned __int128>(scaled.data_[1]) << 64) | scaled.data_[0];
+            sigA = (static_cast<unsigned __int128>(lhs_abs.data_[1]) << 64) | lhs_abs.data_[0];
         else
-            sigA = scaled.data_[0];
+            sigA = lhs_abs.data_[0];
+        if (shift > 0)
+        {
+            scaled >>= shift;
+            if (limbs >= 2)
+                sigA = (static_cast<unsigned __int128>(scaled.data_[1]) << 64) | scaled.data_[0];
+            else
+                sigA = scaled.data_[0];
+        }
+        else if (shift < 0)
+        {
+            sigA <<= -shift;
+        }
         if (p < 128)
             sigA &= ((static_cast<unsigned __int128>(1) << p) - 1);
         T scaled_rhs = std::ldexp(m, p);
@@ -3506,7 +3531,7 @@ private:
             {
                 case 1: {
                     u128 num = data_[0];
-                    u128 q = detail::mulhi_u128(num, inv);
+                    u128 q = detail::mulhi_u128_no_middle_wrap(num, inv);
                     u128 rem = num - q * div;
                     corr(q, rem);
                     quotient.data_[0] = static_cast<limb_type>(q);
@@ -3514,7 +3539,7 @@ private:
                 }
                 case 2: {
                     u128 num = (static_cast<u128>(data_[1]) << 64) | data_[0];
-                    u128 q = detail::mulhi_u128(num, inv);
+                    u128 q = detail::mulhi_u128_no_middle_wrap(num, inv);
                     u128 rem = num - q * div;
                     corr(q, rem);
                     quotient.data_[0] = static_cast<limb_type>(q);
@@ -3524,17 +3549,17 @@ private:
                 case 3: {
                     u128 rem = 0;
                     u128 num = (rem << 64) | data_[2];
-                    u128 q2 = detail::mulhi_u128(num, inv);
+                    u128 q2 = detail::mulhi_u128_no_middle_wrap(num, inv);
                     rem = num - q2 * div;
                     corr(q2, rem);
                     quotient.data_[2] = static_cast<limb_type>(q2);
                     num = (rem << 64) | data_[1];
-                    u128 q1 = detail::mulhi_u128(num, inv);
+                    u128 q1 = detail::mulhi_u128_no_middle_wrap(num, inv);
                     rem = num - q1 * div;
                     corr(q1, rem);
                     quotient.data_[1] = static_cast<limb_type>(q1);
                     num = (rem << 64) | data_[0];
-                    u128 q0 = detail::mulhi_u128(num, inv);
+                    u128 q0 = detail::mulhi_u128_no_middle_wrap(num, inv);
                     rem = num - q0 * div;
                     corr(q0, rem);
                     quotient.data_[0] = static_cast<limb_type>(q0);
@@ -3544,22 +3569,22 @@ private:
                 default: {
                     u128 rem = 0;
                     u128 num = (rem << 64) | data_[3];
-                    u128 q3 = detail::mulhi_u128(num, inv);
+                    u128 q3 = detail::mulhi_u128_no_middle_wrap(num, inv);
                     rem = num - q3 * div;
                     corr(q3, rem);
                     quotient.data_[3] = static_cast<limb_type>(q3);
                     num = (rem << 64) | data_[2];
-                    u128 q2 = detail::mulhi_u128(num, inv);
+                    u128 q2 = detail::mulhi_u128_no_middle_wrap(num, inv);
                     rem = num - q2 * div;
                     corr(q2, rem);
                     quotient.data_[2] = static_cast<limb_type>(q2);
                     num = (rem << 64) | data_[1];
-                    u128 q1 = detail::mulhi_u128(num, inv);
+                    u128 q1 = detail::mulhi_u128_no_middle_wrap(num, inv);
                     rem = num - q1 * div;
                     corr(q1, rem);
                     quotient.data_[1] = static_cast<limb_type>(q1);
                     num = (rem << 64) | data_[0];
-                    u128 q0 = detail::mulhi_u128(num, inv);
+                    u128 q0 = detail::mulhi_u128_no_middle_wrap(num, inv);
                     rem = num - q0 * div;
                     corr(q0, rem);
                     quotient.data_[0] = static_cast<limb_type>(q0);
@@ -3572,7 +3597,7 @@ private:
         for (size_t i = n; i-- > 0;)
         {
             u128 num = (rem << 64) | data_[i];
-            u128 q = detail::mulhi_u128(num, inv);
+            u128 q = detail::mulhi_u128_no_middle_wrap(num, inv);
             rem = num - q * div;
             corr(q, rem);
             quotient.data_[i] = static_cast<limb_type>(q);
@@ -3652,7 +3677,7 @@ private:
         for (size_t i = n; i-- > 0;)
         {
             u128 num = (rem << 64) | data_[i];
-            u128 q = detail::mulhi_u128(num, inv);
+            u128 q = detail::mulhi_u128_no_middle_wrap(num, inv);
             rem = num - q * div;
             corr(q, rem);
         }
@@ -4872,7 +4897,7 @@ private:
                 limb_type & uj2 = u[j + 2];
                 u128 numerator = (static_cast<u128>(uj2) << 64) | uj1;
                 // 1) Initial estimate via reciprocal multiply
-                u128 qhat = v1_is_half_base ? (numerator >> 63) : detail::mulhi_u128(numerator, inv128);
+                u128 qhat = v1_is_half_base ? (numerator >> 63) : detail::mulhi_u128_no_middle_wrap(numerator, inv128);
                 u128 qhat_v1 = v1_is_half_base ? (qhat << 63) : qhat * v1;
                 // The reciprocal estimate cannot overshoot; correct only the
                 // possible one-step underestimate.
@@ -4949,7 +4974,7 @@ private:
                 limb_type & uj2 = u[j + 2];
                 u128 numerator = (static_cast<u128>(uj2) << 64) | uj1;
                 // 1) Initial estimate via reciprocal multiply
-                u128 qhat = v1_is_half_base ? (numerator >> 63) : detail::mulhi_u128(numerator, inv128);
+                u128 qhat = v1_is_half_base ? (numerator >> 63) : detail::mulhi_u128_no_middle_wrap(numerator, inv128);
                 u128 qhat_v1 = v1_is_half_base ? (qhat << 63) : qhat * v1;
                 if ((numerator - qhat_v1) >= v1)
                 {

--- a/tests/arithmetic_divmod_test.cpp
+++ b/tests/arithmetic_divmod_test.cpp
@@ -4,6 +4,36 @@
 template <typename Int>
 using TestAccess = gint::detail::integer_test_access<Int::bits, typename Int::signed_tag>;
 
+namespace
+{
+using u128 = unsigned __int128;
+
+u128 mulhi_u128_reference(u128 a, u128 b)
+{
+    const u128 a0 = static_cast<uint64_t>(a);
+    const u128 a1 = a >> 64;
+    const u128 b0 = static_cast<uint64_t>(b);
+    const u128 b1 = b >> 64;
+    const u128 t0 = a0 * b0;
+    const u128 t1 = a0 * b1;
+    const u128 t2 = a1 * b0;
+    const u128 t3 = a1 * b1;
+    const u128 mid = (t0 >> 64) + static_cast<uint64_t>(t1) + static_cast<uint64_t>(t2);
+    return t3 + (t1 >> 64) + (t2 >> 64) + (mid >> 64);
+}
+} // namespace
+
+TEST(WideIntegerDivision, MulHiU128HandlesMiddleCarry)
+{
+    const u128 all_bits = ~u128(0);
+    const u128 got = gint::detail::mulhi_u128(all_bits, all_bits);
+    const u128 expected = mulhi_u128_reference(all_bits, all_bits);
+
+    EXPECT_EQ(got, expected);
+    EXPECT_EQ(static_cast<uint64_t>(got >> 64), UINT64_MAX);
+    EXPECT_EQ(static_cast<uint64_t>(got), UINT64_MAX - 1);
+}
+
 TEST(WideIntegerDivision, SmallDivMod)
 {
     using UInt256 = gint::integer<256, unsigned>;

--- a/tests/float_interop_edge_test.cpp
+++ b/tests/float_interop_edge_test.cpp
@@ -298,6 +298,36 @@ TEST(FloatInteropEdges, CompareWithLongDouble_PrecisionBoundary)
     EXPECT_FALSE(a2 == d);
 }
 
+TEST(FloatInteropEdges, CompareInteger64WithLongDouble)
+{
+    using S64 = gint::integer<64, signed>;
+    using U64 = gint::integer<64, unsigned>;
+
+    U64 u = 5;
+    const long double five = 5.0L;
+    EXPECT_TRUE(u == five);
+    EXPECT_FALSE(u != five);
+    EXPECT_FALSE(u < five);
+    EXPECT_TRUE(u <= five);
+    EXPECT_FALSE(u > five);
+    EXPECT_TRUE(u >= five);
+    EXPECT_TRUE(five == u);
+    EXPECT_FALSE(five < u);
+    EXPECT_TRUE(five <= u);
+
+    S64 s = -7;
+    const long double neg_seven = -7.0L;
+    EXPECT_TRUE(s == neg_seven);
+    EXPECT_FALSE(s != neg_seven);
+    EXPECT_FALSE(s < neg_seven);
+    EXPECT_TRUE(s <= neg_seven);
+    EXPECT_FALSE(s > neg_seven);
+    EXPECT_TRUE(s >= neg_seven);
+    EXPECT_TRUE(neg_seven == s);
+    EXPECT_FALSE(neg_seven > s);
+    EXPECT_TRUE(neg_seven >= s);
+}
+
 TEST(FloatInteropEdges, ConstructFromNonFiniteValues)
 {
     using S256 = gint::integer<256, signed>;


### PR DESCRIPTION
## 问题

- 现象：`integer<64>` 与 binary128 `long double` 比较时，精确相等值会被判错；`detail::mulhi_u128` 对通用 128x128 高半乘法在中间项进位时结果错误。
- 根因：浮点比较在 `shift < 0` 时借用固定宽度 `integer` 左移对齐，窄位宽会截断；`mulhi_u128` 把两个完整 128 位交叉积直接相加，可能丢失中间进位。

## 做了什么

- 将 `shift < 0` 的 significand 对齐改为在 `unsigned __int128` 域内完成，避免 `integer<64>` 截断。
- 修正 `mulhi_u128` 为通用正确的 split-carry 高半乘法。
- 为现有除法倒数热路径保留带明确前置条件的内部快 helper，避免把通用进位成本压到受约束路径上。
- 增加 `integer<64>` × `long double` 比较回归测试，以及 `mulhi_u128(2^128-1, 2^128-1)` 中间进位回归测试。

## 验证

- 本机 AppleClang：全量单元测试通过。
- Docker/GCC arm64：全量单元测试通过；该环境 `long double` precision 为 113 bits，覆盖 binary128 回归。
- 性能：本机 AppleClang 与 Docker/GCC arm64 均按 `^(Div|Mod)/` 过滤器、`BENCH_BITS=128/256/512/1024` 建立基线并复测。完整矩阵中超过 3% 的噪声项均已 targeted rerun 或 paired main baseline 复核，未确认可重复性能回退。

## 风险

- 除法热路径继续使用受约束快 helper；其前置条件已通过命名和注释与通用 `mulhi_u128` 区分。
- 浮点比较改动只影响 significand 对齐方式，保留原有 `frexp` 比较流程。
