### PR TITLE
fix: avoid double rounding in float conversions

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cassert>
+#include <cfenv>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -3427,7 +3428,27 @@ private:
         limb_type significand = low_limb_after_logical_right_shift(mag, scale);
         const bool guard = test_bit(mag, scale - 1);
         const bool sticky = has_any_bit_below(mag, scale - 1);
-        if (guard && (sticky || (significand & 1)))
+        const bool discarded = guard || sticky;
+        bool increment = false;
+        switch (std::fegetround())
+        {
+            case FE_TONEAREST:
+                increment = guard && (sticky || (significand & 1));
+                break;
+            case FE_UPWARD:
+                increment = !neg && discarded;
+                break;
+            case FE_DOWNWARD:
+                increment = neg && discarded;
+                break;
+            case FE_TOWARDZERO:
+                increment = false;
+                break;
+            default:
+                increment = guard && (sticky || (significand & 1));
+                break;
+        }
+        if (increment)
         {
             ++significand;
             if (significand == (limb_type(1) << digits))

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1553,9 +1553,9 @@ public:
         return neg ? -res : res;
     }
 
-    explicit operator double() const noexcept { return static_cast<double>(static_cast<long double>(*this)); }
+    explicit operator double() const noexcept { return to_binary_float<double>(); }
 
-    explicit operator float() const noexcept { return static_cast<float>(static_cast<long double>(*this)); }
+    explicit operator float() const noexcept { return to_binary_float<float>(); }
 
     GINT_CONSTEXPR14 explicit operator bool() const noexcept { return !is_zero(); }
 
@@ -3362,6 +3362,83 @@ private:
                 return i * 64 + 63 - __builtin_clzll(data_[i]);
         }
         return -1;
+    }
+
+    static bool test_bit(const integer & value, int bit) noexcept
+    {
+        return bit >= 0 && bit < static_cast<int>(Bits) && ((value.data_[static_cast<size_t>(bit) / 64] >> (bit % 64)) & 1);
+    }
+
+    static bool has_any_bit_below(const integer & value, int bit) noexcept
+    {
+        if (bit <= 0)
+            return false;
+        size_t full_limbs = static_cast<size_t>(bit) / 64;
+        const unsigned rem = static_cast<unsigned>(bit % 64);
+        if (full_limbs > limbs)
+            full_limbs = limbs;
+        for (size_t i = 0; i < full_limbs; ++i)
+            if (value.data_[i])
+                return true;
+        if (full_limbs < limbs && rem != 0)
+        {
+            const limb_type mask = (limb_type(1) << rem) - 1;
+            return (value.data_[full_limbs] & mask) != 0;
+        }
+        return false;
+    }
+
+    static limb_type low_limb_after_logical_right_shift(const integer & value, int shift) noexcept
+    {
+        const size_t limb_shift = static_cast<size_t>(shift) / 64;
+        const unsigned bit_shift = static_cast<unsigned>(shift % 64);
+        if (limb_shift >= limbs)
+            return 0;
+
+        limb_type result = value.data_[limb_shift] >> bit_shift;
+        if (bit_shift != 0 && limb_shift + 1 < limbs)
+            result |= value.data_[limb_shift + 1] << (64 - bit_shift);
+        return result;
+    }
+
+    template <typename Float>
+    Float to_binary_float() const noexcept
+    {
+        static_assert(std::numeric_limits<Float>::digits < 64, "binary float conversion expects fewer than 64 significand bits");
+        if (is_zero())
+            return Float(0);
+
+        const bool neg = std::is_same<Signed, signed>::value && (data_[limbs - 1] >> 63);
+        integer mag = neg ? -*this : *this;
+        const int hb = mag.highest_bit();
+        const int digits = std::numeric_limits<Float>::digits;
+        if (hb < digits)
+        {
+            Float res = 0;
+            for (size_t i = limbs; i-- > 0;)
+            {
+                res = std::ldexp(res, 64);
+                res += static_cast<Float>(mag.data_[i]);
+            }
+            return neg ? -res : res;
+        }
+
+        int scale = hb - (digits - 1);
+        limb_type significand = low_limb_after_logical_right_shift(mag, scale);
+        const bool guard = test_bit(mag, scale - 1);
+        const bool sticky = has_any_bit_below(mag, scale - 1);
+        if (guard && (sticky || (significand & 1)))
+        {
+            ++significand;
+            if (significand == (limb_type(1) << digits))
+            {
+                significand >>= 1;
+                ++scale;
+            }
+        }
+
+        const Float res = std::ldexp(static_cast<Float>(significand), scale);
+        return neg ? -res : res;
     }
 
     template <size_t L = limbs>

--- a/tests/conversion_test.cpp
+++ b/tests/conversion_test.cpp
@@ -1,4 +1,5 @@
 #include <array>
+#include <cmath>
 #include <limits>
 #include <sstream>
 #include <type_traits>
@@ -100,6 +101,56 @@ TEST(WideIntegerConversion, FloatingPoint)
     double d2 = -789.0;
     gint::integer<128, signed> s = d2;
     EXPECT_EQ(s, -789);
+}
+
+TEST(WideIntegerConversion, DoubleConversionAvoidsLongDoubleDoubleRounding)
+{
+    using U128 = gint::integer<128, unsigned>;
+    const unsigned __int128 native = (static_cast<unsigned __int128>(1) << 64) + (1ULL << 11) + 1;
+    U128 wide = U128(1);
+    wide <<= 64;
+    wide += U128(1ULL << 11);
+    wide += U128(1);
+
+    EXPECT_EQ(static_cast<double>(wide), static_cast<double>(native));
+
+    using S128 = gint::integer<128, signed>;
+    S128 signed_wide = S128(1);
+    signed_wide <<= 64;
+    signed_wide += S128(1ULL << 11);
+    signed_wide += S128(1);
+    signed_wide = -signed_wide;
+    const __int128 signed_native = -static_cast<__int128>(native);
+    EXPECT_EQ(static_cast<double>(signed_wide), static_cast<double>(signed_native));
+}
+
+TEST(WideIntegerConversion, FloatConversionAvoidsLongDoubleDoubleRounding)
+{
+    using U128 = gint::integer<128, unsigned>;
+    const unsigned __int128 native = (static_cast<unsigned __int128>(1) << 64) + (static_cast<unsigned __int128>(1) << 40) + 1;
+    U128 wide = U128(1);
+    wide <<= 64;
+    wide += U128(1) << 40;
+    wide += U128(1);
+
+    EXPECT_EQ(static_cast<float>(wide), static_cast<float>(native));
+
+    using S128 = gint::integer<128, signed>;
+    S128 signed_wide = S128(1);
+    signed_wide <<= 64;
+    signed_wide += S128(1) << 40;
+    signed_wide += S128(1);
+    signed_wide = -signed_wide;
+    const __int128 signed_native = -static_cast<__int128>(native);
+    EXPECT_EQ(static_cast<float>(signed_wide), static_cast<float>(signed_native));
+}
+
+TEST(WideIntegerConversion, FloatConversionSignedMinMagnitude)
+{
+    using S128 = gint::integer<128, signed>;
+    const S128 min128 = std::numeric_limits<S128>::min();
+    EXPECT_EQ(static_cast<double>(min128), -std::ldexp(1.0, 127));
+    EXPECT_EQ(static_cast<float>(min128), -std::ldexp(1.0f, 127));
 }
 
 TEST(WideIntegerConversion, FloatCtorAndAssignLongDouble)

--- a/tests/conversion_test.cpp
+++ b/tests/conversion_test.cpp
@@ -1,4 +1,5 @@
 #include <array>
+#include <cfenv>
 #include <cmath>
 #include <limits>
 #include <sstream>
@@ -122,6 +123,46 @@ TEST(WideIntegerConversion, DoubleConversionAvoidsLongDoubleDoubleRounding)
     signed_wide = -signed_wide;
     const __int128 signed_native = -static_cast<__int128>(native);
     EXPECT_EQ(static_cast<double>(signed_wide), static_cast<double>(signed_native));
+}
+
+TEST(WideIntegerConversion, DoubleConversionRespectsCurrentRoundingMode)
+{
+    struct RoundingGuard
+    {
+        int old_round;
+        RoundingGuard()
+            : old_round(std::fegetround())
+        {
+        }
+        ~RoundingGuard() { std::fesetround(old_round); }
+    } guard;
+
+    using U128 = gint::integer<128, unsigned>;
+    using S128 = gint::integer<128, signed>;
+    const double base = std::ldexp(1.0, 53);
+    U128 positive = U128(1);
+    positive <<= 53;
+    positive += U128(3);
+    S128 negative = S128(1);
+    negative <<= 53;
+    negative += S128(3);
+    negative = -negative;
+
+    ASSERT_EQ(std::fesetround(FE_DOWNWARD), 0);
+    EXPECT_EQ(static_cast<double>(positive), base + 2.0);
+    EXPECT_EQ(static_cast<double>(negative), -(base + 4.0));
+
+    ASSERT_EQ(std::fesetround(FE_UPWARD), 0);
+    EXPECT_EQ(static_cast<double>(positive), base + 4.0);
+    EXPECT_EQ(static_cast<double>(negative), -(base + 2.0));
+
+    ASSERT_EQ(std::fesetround(FE_TOWARDZERO), 0);
+    EXPECT_EQ(static_cast<double>(positive), base + 2.0);
+    EXPECT_EQ(static_cast<double>(negative), -(base + 2.0));
+
+    ASSERT_EQ(std::fesetround(FE_TONEAREST), 0);
+    EXPECT_EQ(static_cast<double>(positive), base + 4.0);
+    EXPECT_EQ(static_cast<double>(negative), -(base + 4.0));
 }
 
 TEST(WideIntegerConversion, FloatConversionAvoidsLongDoubleDoubleRounding)


### PR DESCRIPTION
## 问题

- 现象：`operator double()` / `operator float()` 先转 `long double` 再转目标类型，在 x86_64 Linux 的 80-bit `long double` 平台上会触发双重舍入，导致部分宽整数到浮点的结果与原生整数转换不一致。
- 根因：中间 `long double` 只有 64 位有效尾数，先按中间精度舍入后再转到 `double` / `float`，会丢失目标类型一次舍入所需的 sticky 信息。

## 做了什么

- 将 `double` / `float` 转换改为直接按目标浮点精度提取 significand、guard bit 和 sticky bit，并执行 ties-to-even 一次舍入。
- 对 signed MIN 的 magnitude 路径使用 limb 级逻辑右移提取，避免 signed 算术右移污染结果。
- 增加 double / float 双重舍入反例、正负数和 signed MIN 转换回归测试。

## 验证

- 本机 AppleClang 全量单元测试通过。
- x86_64 Linux/GCC 全量单元测试通过，并确认原 double-rounding 复现程序输出与原生转换一致。
- 本机 AppleClang 对常见算术与 ToString benchmark 做 main/current paired 复测；初次噪声项用更长运行时间复核，未发现可重复性能回退。

## 风险

- 风险集中在整数到 `double` / `float` 的舍入边界；已覆盖 ties-to-even、正负号和 signed MIN。`long double` 转换路径保持不变。