### PR TITLE
fix: add explicit integer conversions

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1411,6 +1411,21 @@ private:
             data_[i] = fill;
     }
 
+    template <size_t I, size_t OtherBits, typename OtherSigned>
+    static constexpr typename std::enable_if<(I < integer<OtherBits, OtherSigned>::limbs), limb_type>::type
+    limb_from_integer(const integer<OtherBits, OtherSigned> & other) noexcept
+    {
+        return other.data_[I];
+    }
+
+    template <size_t I, size_t OtherBits, typename OtherSigned>
+    static constexpr typename std::enable_if<(I >= integer<OtherBits, OtherSigned>::limbs), limb_type>::type
+    limb_from_integer(const integer<OtherBits, OtherSigned> & other) noexcept
+    {
+        return std::is_same<OtherSigned, signed>::value && (other.data_[integer<OtherBits, OtherSigned>::limbs - 1] >> 63) ? ~limb_type(0)
+                                                                                                                           : limb_type(0);
+    }
+
 public:
     // Constructors
     constexpr integer() noexcept
@@ -1425,8 +1440,8 @@ public:
         typename OtherSigned,
         typename std::enable_if<!(OtherBits == Bits && std::is_same<OtherSigned, Signed>::value), int>::type = 0>
     GINT_CONSTEXPR14 explicit integer(const integer<OtherBits, OtherSigned> & other) noexcept
+        : integer(other, typename detail::make_index_sequence<limbs>::type())
     {
-        assign_integer(other);
     }
 
     // Assignment operators
@@ -1457,6 +1472,12 @@ public:
     }
 
 private:
+    template <size_t OtherBits, typename OtherSigned, size_t... I>
+    constexpr integer(const integer<OtherBits, OtherSigned> & other, detail::index_sequence<I...>) noexcept
+        : data_{limb_from_integer<I>(other)...}
+    {
+    }
+
     template <typename T, size_t... I>
     constexpr integer(T v, detail::index_sequence<I...>) noexcept
         : data_{limb_from<T, I>(v)...}

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1397,6 +1397,20 @@ private:
     };
     explicit integer(uninitialized_tag) noexcept { }
 
+    template <size_t OtherBits, typename OtherSigned>
+    GINT_CONSTEXPR14 void assign_integer(const integer<OtherBits, OtherSigned> & other) noexcept
+    {
+        const size_t src_limbs = integer<OtherBits, OtherSigned>::limbs;
+        const size_t common_limbs = limbs < src_limbs ? limbs : src_limbs;
+        for (size_t i = 0; i < common_limbs; ++i)
+            data_[i] = other.data_[i];
+
+        const bool source_negative = std::is_same<OtherSigned, signed>::value && (other.data_[src_limbs - 1] >> 63);
+        const limb_type fill = source_negative ? ~limb_type(0) : limb_type(0);
+        for (size_t i = common_limbs; i < limbs; ++i)
+            data_[i] = fill;
+    }
+
 public:
     // Constructors
     constexpr integer() noexcept
@@ -1406,9 +1420,28 @@ public:
     constexpr integer(const integer &) noexcept = default;
     constexpr integer(integer &&) noexcept = default;
 
+    template <
+        size_t OtherBits,
+        typename OtherSigned,
+        typename std::enable_if<!(OtherBits == Bits && std::is_same<OtherSigned, Signed>::value), int>::type = 0>
+    GINT_CONSTEXPR14 explicit integer(const integer<OtherBits, OtherSigned> & other) noexcept
+    {
+        assign_integer(other);
+    }
+
     // Assignment operators
     GINT_CONSTEXPR14 integer & operator=(const integer &) noexcept = default;
     GINT_CONSTEXPR14 integer & operator=(integer &&) noexcept = default;
+
+    template <
+        size_t OtherBits,
+        typename OtherSigned,
+        typename std::enable_if<!(OtherBits == Bits && std::is_same<OtherSigned, Signed>::value), int>::type = 0>
+    GINT_CONSTEXPR14 integer & operator=(const integer<OtherBits, OtherSigned> & other) noexcept
+    {
+        assign_integer(other);
+        return *this;
+    }
 
     template <typename T, typename std::enable_if<detail::is_integral<T>::value, int>::type = 0>
     constexpr integer(T v) noexcept

--- a/tests/conversion_test.cpp
+++ b/tests/conversion_test.cpp
@@ -8,6 +8,38 @@
 // Compile-time convertibility checks (moved from removed compile_test.cpp)
 static_assert(std::is_convertible<int, gint::Int256>::value, "int should convert to Int256 implicitly");
 static_assert(!std::is_convertible<gint::Int256, int>::value, "Int256 should not implicitly convert to int");
+static_assert(std::is_constructible<gint::Int128, gint::UInt128>::value, "UInt128 should explicitly construct Int128");
+static_assert(std::is_constructible<gint::UInt256, gint::Int128>::value, "Int128 should explicitly construct UInt256");
+static_assert(!std::is_convertible<gint::UInt128, gint::Int128>::value, "integer signedness conversion should stay explicit");
+static_assert(std::is_assignable<gint::Int256 &, gint::UInt128>::value, "UInt128 should assign to Int256 explicitly");
+
+template <size_t SmallBits, size_t LargeBits>
+static void test_integer_conversion_width_pair()
+{
+    using USmall = gint::integer<SmallBits, unsigned>;
+    using SSmall = gint::integer<SmallBits, signed>;
+    using ULarge = gint::integer<LargeBits, unsigned>;
+    using SLarge = gint::integer<LargeBits, signed>;
+
+    const SSmall minus_one = SSmall(-1);
+    const SLarge sign_extended_signed = static_cast<SLarge>(minus_one);
+    const ULarge sign_extended_unsigned = static_cast<ULarge>(minus_one);
+    EXPECT_EQ(sign_extended_signed, SLarge(-1));
+    EXPECT_EQ(sign_extended_unsigned, std::numeric_limits<ULarge>::max());
+
+    const USmall small_max = std::numeric_limits<USmall>::max();
+    const ULarge zero_extended = static_cast<ULarge>(small_max);
+    EXPECT_EQ(gint::to_string(zero_extended), gint::to_string(small_max));
+
+    ULarge high_unsigned = static_cast<ULarge>(USmall(77));
+    high_unsigned += ULarge(1) << SmallBits;
+    EXPECT_EQ(static_cast<USmall>(high_unsigned), USmall(77));
+
+    SLarge high_signed = SLarge(1);
+    high_signed <<= SmallBits;
+    high_signed -= SLarge(123);
+    EXPECT_EQ(static_cast<SSmall>(high_signed), SSmall(-123));
+}
 
 TEST(WideIntegerConversion, Int128NegativeConversion)
 {
@@ -241,6 +273,52 @@ TEST(WideIntegerConversion, SignedConversionInt128)
     gint::integer<256, signed> negative = -1;
     auto neg_explicit = static_cast<__int128>(negative);
     EXPECT_TRUE(neg_explicit == static_cast<__int128>(-1));
+}
+
+TEST(WideIntegerConversion, SameWidthIntegerConversionPreservesBits)
+{
+    using S128 = gint::integer<128, signed>;
+    using U128 = gint::integer<128, unsigned>;
+
+    U128 sign_bit = U128(1);
+    sign_bit <<= 127;
+    const S128 min_value = static_cast<S128>(sign_bit);
+    EXPECT_EQ(min_value, std::numeric_limits<S128>::min());
+    EXPECT_EQ(static_cast<U128>(min_value), sign_bit);
+
+    const S128 negative = S128(-1);
+    EXPECT_EQ(static_cast<U128>(negative), std::numeric_limits<U128>::max());
+    EXPECT_EQ(static_cast<S128>(std::numeric_limits<U128>::max()), S128(-1));
+}
+
+TEST(WideIntegerConversion, CrossWidthIntegerConversionExtendsAndNarrows)
+{
+    test_integer_conversion_width_pair<64, 128>();
+    test_integer_conversion_width_pair<128, 256>();
+    test_integer_conversion_width_pair<256, 512>();
+    test_integer_conversion_width_pair<512, 1024>();
+}
+
+TEST(WideIntegerConversion, CrossWidthIntegerAssignment)
+{
+    using S128 = gint::integer<128, signed>;
+    using U128 = gint::integer<128, unsigned>;
+    using S256 = gint::integer<256, signed>;
+    using U256 = gint::integer<256, unsigned>;
+
+    S256 signed_assigned;
+    signed_assigned = S128(-42);
+    EXPECT_EQ(signed_assigned, S256(-42));
+
+    U256 unsigned_assigned;
+    unsigned_assigned = S128(-1);
+    EXPECT_EQ(unsigned_assigned, std::numeric_limits<U256>::max());
+
+    U128 high_unsigned = U128(1);
+    high_unsigned <<= 127;
+    S256 positive_assigned;
+    positive_assigned = high_unsigned;
+    EXPECT_EQ(positive_assigned, S256(1) << 127);
 }
 
 TEST(WideIntegerConversion, SignedNarrowWidthUnsignedComparisons)

--- a/tests/conversion_test.cpp
+++ b/tests/conversion_test.cpp
@@ -13,6 +13,18 @@ static_assert(std::is_constructible<gint::UInt256, gint::Int128>::value, "Int128
 static_assert(!std::is_convertible<gint::UInt128, gint::Int128>::value, "integer signedness conversion should stay explicit");
 static_assert(std::is_assignable<gint::Int256 &, gint::UInt128>::value, "UInt128 should assign to Int256 explicitly");
 
+#if __cplusplus >= 201402L
+constexpr bool constexpr_integer_conversion_works()
+{
+    constexpr gint::UInt128 one = 1;
+    constexpr gint::Int256 widened(one);
+    constexpr gint::Int128 minus_one = -1;
+    constexpr gint::UInt256 sign_extended(minus_one);
+    return widened == gint::Int256(1) && sign_extended == std::numeric_limits<gint::UInt256>::max();
+}
+static_assert(constexpr_integer_conversion_works(), "integer conversion constructors should be constexpr in C++14+");
+#endif
+
 template <size_t SmallBits, size_t LargeBits>
 static void test_integer_conversion_width_pair()
 {


### PR DESCRIPTION
## 问题

- 现象：不同 `integer<Bits, Signed>` 实例之间不能直接显式转换，例如同位宽 signed/unsigned 互转、128 位到 256 位扩宽、256 位到 128 位窄化都需要用户手动拆 limb。
- 根因：类只提供同一实例的拷贝/移动构造和内建整数转换，缺少跨位宽/跨 signedness 的 integer 转换构造与赋值。

## 做了什么

- 增加跨 `integer<OtherBits, OtherSigned>` 的 explicit 构造函数。
- 增加跨 `integer<OtherBits, OtherSigned>` 的赋值运算符。
- 转换语义按补码位模式实现：窄化保留低位，unsigned 源扩宽零扩展，signed 负值源扩宽符号扩展，同位宽 signed/unsigned 互转保留位模式。
- 增加 64/128/256/512/1024 位宽、同位宽 signedness 互转、扩宽、窄化和赋值回归测试。

## 验证

- 本机 AppleClang 全量单元测试通过。
- Docker/GCC 全量单元测试通过。
- 本机 AppleClang 对常见算术与 ToString benchmark 做 main/current smoke 对比；新增转换不进入现有热路径，未发现性能回退。

## 风险

- 新构造函数保持 explicit，不会引入隐式 integer signedness/width 转换。
- 行为按现有补码 limb 表示复制和扩展；风险主要在非 64 倍数位宽，本次测试覆盖库当前主要生产位宽。