### PR TITLE
fix: complete limits and constexpr comparisons

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -3084,7 +3084,7 @@ public:
         return !(lhs == rhs);
     }
 
-    friend bool operator<(const integer & lhs, const integer & rhs) noexcept
+    GINT_CONSTEXPR14 friend bool operator<(const integer & lhs, const integer & rhs) noexcept
     {
         if (std::is_same<Signed, signed>::value)
         {
@@ -3101,11 +3101,11 @@ public:
         return false;
     }
 
-    friend bool operator>(const integer & lhs, const integer & rhs) noexcept { return rhs < lhs; }
+    GINT_CONSTEXPR14 friend bool operator>(const integer & lhs, const integer & rhs) noexcept { return rhs < lhs; }
 
-    friend bool operator<=(const integer & lhs, const integer & rhs) noexcept { return !(rhs < lhs); }
+    GINT_CONSTEXPR14 friend bool operator<=(const integer & lhs, const integer & rhs) noexcept { return !(rhs < lhs); }
 
-    friend bool operator>=(const integer & lhs, const integer & rhs) noexcept { return !(lhs < rhs); }
+    GINT_CONSTEXPR14 friend bool operator>=(const integer & lhs, const integer & rhs) noexcept { return !(lhs < rhs); }
 
     template <typename T, typename std::enable_if<detail::is_integral<T>::value, int>::type = 0>
     friend GINT_CONSTEXPR14 bool operator<(const integer & lhs, T rhs) noexcept
@@ -5198,6 +5198,7 @@ public:
     static constexpr bool has_infinity = false;
     static constexpr bool has_quiet_NaN = false;
     static constexpr bool has_signaling_NaN = false;
+    static constexpr std::float_denorm_style has_denorm = std::denorm_absent;
     static constexpr bool has_denorm_loss = false;
     static constexpr std::float_round_style round_style = std::round_toward_zero;
     static constexpr bool is_iec559 = false;
@@ -5241,6 +5242,8 @@ template <size_t Bits, typename Signed>
 constexpr bool numeric_limits<gint::integer<Bits, Signed>>::has_quiet_NaN;
 template <size_t Bits, typename Signed>
 constexpr bool numeric_limits<gint::integer<Bits, Signed>>::has_signaling_NaN;
+template <size_t Bits, typename Signed>
+constexpr std::float_denorm_style numeric_limits<gint::integer<Bits, Signed>>::has_denorm;
 template <size_t Bits, typename Signed>
 constexpr bool numeric_limits<gint::integer<Bits, Signed>>::has_denorm_loss;
 template <size_t Bits, typename Signed>

--- a/tests/comparison_test.cpp
+++ b/tests/comparison_test.cpp
@@ -2,6 +2,21 @@
 #include <gint/gint.h>
 #include <gtest/gtest.h>
 
+#if __cplusplus >= 201402L
+constexpr gint::integer<128, unsigned> constexpr_u5(5);
+constexpr gint::integer<128, unsigned> constexpr_u10(10);
+constexpr gint::integer<128, signed> constexpr_sneg(-1);
+constexpr gint::integer<128, signed> constexpr_spos(1);
+static_assert(constexpr_u5 < constexpr_u10, "integer < integer should be constexpr");
+static_assert(constexpr_u10 > constexpr_u5, "integer > integer should be constexpr");
+static_assert(constexpr_u5 <= constexpr_u5, "integer <= integer should be constexpr");
+static_assert(constexpr_u10 >= constexpr_u5, "integer >= integer should be constexpr");
+static_assert(constexpr_sneg < constexpr_spos, "signed integer comparison should be constexpr");
+static_assert(gint::integer<128, signed>(5) < 6, "mixed integer < should be constexpr");
+static_assert(6 > gint::integer<128, signed>(5), "mixed integer > should be constexpr");
+static_assert(gint::integer<64, signed>(0) < 0x8000000000000005ULL, "promoted mixed comparison should be constexpr");
+#endif
+
 TEST(WideIntegerComparison, UnsignedBasic)
 {
     gint::integer<128, unsigned> a = 5;

--- a/tests/numeric_limits_test.cpp
+++ b/tests/numeric_limits_test.cpp
@@ -31,6 +31,8 @@ TEST(WideIntegerNumericLimits, Basic)
     static_assert(!std::numeric_limits<S>::has_quiet_NaN, "numeric_limits<S>::has_quiet_NaN");
     static_assert(!std::numeric_limits<U>::has_signaling_NaN, "numeric_limits<U>::has_signaling_NaN");
     static_assert(!std::numeric_limits<S>::has_signaling_NaN, "numeric_limits<S>::has_signaling_NaN");
+    static_assert(std::numeric_limits<U>::has_denorm == std::denorm_absent, "numeric_limits<U>::has_denorm");
+    static_assert(std::numeric_limits<S>::has_denorm == std::denorm_absent, "numeric_limits<S>::has_denorm");
     static_assert(!std::numeric_limits<U>::has_denorm_loss, "numeric_limits<U>::has_denorm_loss");
     static_assert(!std::numeric_limits<S>::has_denorm_loss, "numeric_limits<S>::has_denorm_loss");
     static_assert(std::numeric_limits<U>::round_style == std::round_toward_zero, "round_style U");


### PR DESCRIPTION
## 问题

- 现象：`std::numeric_limits<integer<...>>` 缺少完整特化应提供的 `has_denorm` 成员，直接访问会编译失败。
- 根因：专门化手动列出了多数成员，但遗漏了 `std::float_denorm_style has_denorm`；同时同类型关系比较未标记 `GINT_CONSTEXPR14`，导致 C++14/17 下 `<` / `>` / `<=` / `>=` 不能用于常量求值，混合整型比较的 constexpr 标记也无法真正生效。

## 做了什么

- 为 `numeric_limits<gint::integer<...>>` 增加 `has_denorm = std::denorm_absent` 及类外定义。
- 将同类型关系比较标记为 `GINT_CONSTEXPR14`，保持 C++11 下原行为不变。
- 增加 `has_denorm` static_assert，并在 C++14+ 下增加同类型和混合整型比较的 constexpr static_assert。

## 验证

- 本机 AppleClang C++11 全量单元测试通过。
- 本机 AppleClang C++17 测试目标编译通过，并运行 comparison/numeric_limits 相关测试通过。
- Docker/GCC C++11 全量单元测试通过。
- 本次只补 traits 和 constexpr 标记，运行时比较实现未变，不进入额外热路径。

## 风险

- 低。C++11 下 `GINT_CONSTEXPR14` 为空，运行时实现保持不变；C++14+ 仅开放已有逻辑的常量求值能力。