### PR TITLE
fix: add std hash support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ if(GINT_BUILD_TESTS)
         tests/conversion_test.cpp
         tests/float_interop_edge_test.cpp
         tests/fmt_support_test.cpp
+        tests/hash_test.cpp
         tests/numeric_limits_test.cpp
         tests/property_test.cpp
         tests/shift_test.cpp

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <ostream>
 #include <stdexcept>
@@ -1381,6 +1382,7 @@ public:
     template <size_t, typename>
     friend class integer;
     friend class std::numeric_limits<integer<Bits, Signed>>;
+    friend struct std::hash<integer<Bits, Signed>>;
 #ifdef GINT_TEST_ACCESS
     friend struct detail::integer_test_access<Bits, Signed>;
 #endif
@@ -5271,6 +5273,22 @@ template <size_t Bits, typename Signed>
 constexpr bool numeric_limits<gint::integer<Bits, Signed>>::traps;
 template <size_t Bits, typename Signed>
 constexpr bool numeric_limits<gint::integer<Bits, Signed>>::tinyness_before;
+
+template <size_t Bits, typename Signed>
+struct hash<gint::integer<Bits, Signed>>
+{
+    size_t operator()(const gint::integer<Bits, Signed> & value) const noexcept
+    {
+        using Int = gint::integer<Bits, Signed>;
+        size_t seed = 0;
+        for (size_t i = 0; i < Int::limbs; ++i)
+        {
+            const size_t h = std::hash<typename Int::limb_type>()(value.data_[i]);
+            seed ^= h + static_cast<size_t>(0x9e3779b97f4a7c15ULL) + (seed << 6) + (seed >> 2);
+        }
+        return seed;
+    }
+};
 } // namespace std
 
 namespace gint

--- a/tests/hash_test.cpp
+++ b/tests/hash_test.cpp
@@ -1,0 +1,48 @@
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <gint/gint.h>
+#include <gtest/gtest.h>
+
+TEST(WideIntegerHash, SupportsUnorderedSet)
+{
+    using U128 = gint::integer<128, unsigned>;
+    U128 a = U128(1) << 100;
+    U128 b = a + U128(7);
+
+    std::unordered_set<U128> values;
+    values.insert(a);
+    values.insert(b);
+
+    EXPECT_EQ(values.count(a), 1u);
+    EXPECT_EQ(values.count(b), 1u);
+    EXPECT_EQ(values.count(U128(3)), 0u);
+}
+
+TEST(WideIntegerHash, SupportsUnorderedMap)
+{
+    using S256 = gint::integer<256, signed>;
+    S256 key = -(S256(1) << 200);
+    key += S256(42);
+
+    std::unordered_map<S256, int> values;
+    values[key] = 17;
+
+    EXPECT_EQ(values.find(key)->second, 17);
+    EXPECT_EQ(values.count(S256(-42)), 0u);
+}
+
+TEST(WideIntegerHash, EqualValuesHaveEqualHashes)
+{
+    using U256 = gint::integer<256, unsigned>;
+    U256 lhs = (U256(1) << 180) + U256(123);
+    U256 rhs = lhs;
+
+    std::hash<U256> hasher;
+    EXPECT_EQ(hasher(lhs), hasher(rhs));
+}
+
+static_assert(std::is_default_constructible<std::hash<gint::UInt128>>::value, "std::hash<UInt128> should be default constructible");
+static_assert(
+    noexcept(std::declval<std::hash<gint::UInt128> &>()(std::declval<const gint::UInt128 &>())), "std::hash<UInt128> should be noexcept");


### PR DESCRIPTION
## 问题
- 现象：`gint::integer` 不能直接作为 `std::unordered_map` / `std::unordered_set` key，因为没有 `std::hash` 特化。
- 根因：库只提供比较和字符串转换，没有为标准无序容器提供 hash 支持。

## 做了什么
- 为 `gint::integer<Bits, Signed>` 增加 `std::hash` 特化。
- hash 直接按 limb 做组合，不经过 `to_string`。
- 增加 unordered_set / unordered_map / equal-values hash 回归测试，并纳入核心测试源。

## 验证
- 本机 AppleClang 全量单元测试通过。
- Docker/GCC 全量单元测试通过。
- 本次新增的是可选 `std::hash` 调用路径，不改变既有算术/转换热路径。

## 风险
- 低。hash 值不承诺跨版本稳定，只需满足同类型相等值 hash 相等；现有相等/比较语义不变。