### PR TITLE
fix: honor integer format specs

### DIFF
--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -5829,7 +5829,13 @@ struct formatter<gint::integer<Bits, Signed>>
     bool alternate = false;
     unsigned width = 0;
     int dynamic_width_arg_id = -1;
+    basic_string_view<char> dynamic_width_arg_name;
+    bool dynamic_width_is_named = false;
     char presentation = 0;
+
+    static FMT_CONSTEXPR bool is_name_start(char ch) { return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || ch == '_'; }
+
+    static FMT_CONSTEXPR bool is_name_char(char ch) { return is_name_start(ch) || (ch >= '0' && ch <= '9'); }
 
     template <typename ParseContext>
     FMT_CONSTEXPR auto parse(ParseContext & ctx) -> typename ParseContext::iterator
@@ -5897,6 +5903,19 @@ struct formatter<gint::integer<Bits, Signed>>
             if (it != end && *it == '}')
             {
                 dynamic_width_arg_id = ctx.next_arg_id();
+                ++it;
+            }
+            else if (it != end && is_name_start(*it))
+            {
+                const auto name_begin = it;
+                ++it;
+                while (it != end && is_name_char(*it))
+                    ++it;
+                if (it == end || *it != '}')
+                    throw fmt::format_error("invalid format specifier for gint::integer");
+                dynamic_width_arg_name = basic_string_view<char>(&*name_begin, static_cast<size_t>(it - name_begin));
+                dynamic_width_is_named = true;
+                ctx.check_arg_id(dynamic_width_arg_name);
                 ++it;
             }
             else
@@ -6037,6 +6056,8 @@ struct formatter<gint::integer<Bits, Signed>>
         unsigned resolved_width = width;
         if (dynamic_width_arg_id >= 0)
             resolved_width = visit_dynamic_width_arg(ctx.arg(dynamic_width_arg_id));
+        else if (dynamic_width_is_named)
+            resolved_width = visit_dynamic_width_arg(ctx.arg(dynamic_width_arg_name));
         if (resolved_width > text.size())
         {
             const size_t padding = resolved_width - text.size();

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -5828,6 +5828,7 @@ struct formatter<gint::integer<Bits, Signed>>
     char sign = 0;
     bool alternate = false;
     unsigned width = 0;
+    int dynamic_width_arg_id = -1;
     char presentation = 0;
 
     template <typename ParseContext>
@@ -5838,18 +5839,21 @@ struct formatter<gint::integer<Bits, Signed>>
         if (it == end || *it == '}')
             return it;
 
+        bool explicit_align = false;
         auto next = it;
         ++next;
         if (next != end && (*next == '<' || *next == '>' || *next == '^' || *next == '='))
         {
             fill = *it;
             align = *next;
+            explicit_align = true;
             it = next;
             ++it;
         }
         else if (*it == '<' || *it == '>' || *it == '^' || *it == '=')
         {
             align = *it;
+            explicit_align = true;
             ++it;
         }
 
@@ -5867,14 +5871,17 @@ struct formatter<gint::integer<Bits, Signed>>
 
         if (it != end && *it == '0')
         {
-#    if FMT_VERSION < 120000
-            fill = '0';
-#    endif
-            if (align == '>')
+            if (align == '>' && !explicit_align)
             {
                 align = '=';
                 fill = '0';
             }
+#    if FMT_VERSION < 120000
+            else
+            {
+                fill = '0';
+            }
+#    endif
             ++it;
         }
 
@@ -5882,6 +5889,32 @@ struct formatter<gint::integer<Bits, Signed>>
         {
             width = width * 10u + static_cast<unsigned>(*it - '0');
             ++it;
+        }
+
+        if (it != end && *it == '{')
+        {
+            ++it;
+            if (it != end && *it == '}')
+            {
+                dynamic_width_arg_id = ctx.next_arg_id();
+                ++it;
+            }
+            else
+            {
+                int arg_id = 0;
+                bool has_arg_id = false;
+                while (it != end && *it >= '0' && *it <= '9')
+                {
+                    has_arg_id = true;
+                    arg_id = arg_id * 10 + static_cast<int>(*it - '0');
+                    ++it;
+                }
+                if (!has_arg_id || it == end || *it != '}')
+                    throw fmt::format_error("invalid format specifier for gint::integer");
+                ctx.check_arg_id(arg_id);
+                dynamic_width_arg_id = arg_id;
+                ++it;
+            }
         }
 
         if (it != end && *it != '}')
@@ -5896,6 +5929,49 @@ struct formatter<gint::integer<Bits, Signed>>
         if (it != end && *it != '}')
             throw fmt::format_error("invalid format specifier for gint::integer");
         return it;
+    }
+
+    struct dynamic_width_visitor
+    {
+        unsigned operator()(int value) const { return from_signed(value); }
+        unsigned operator()(long value) const { return from_signed(value); }
+        unsigned operator()(long long value) const { return from_signed(value); }
+        unsigned operator()(unsigned value) const { return value; }
+        unsigned operator()(unsigned long value) const { return from_unsigned(value); }
+        unsigned operator()(unsigned long long value) const { return from_unsigned(value); }
+
+        template <typename T>
+        unsigned operator()(const T &) const
+        {
+            throw fmt::format_error("width is not integer");
+        }
+
+    private:
+        template <typename T>
+        static unsigned from_signed(T value)
+        {
+            if (value < 0)
+                throw fmt::format_error("negative width");
+            return from_unsigned(static_cast<typename std::make_unsigned<T>::type>(value));
+        }
+
+        template <typename T>
+        static unsigned from_unsigned(T value)
+        {
+            if (value > static_cast<T>((std::numeric_limits<unsigned>::max)()))
+                throw fmt::format_error("width is too large");
+            return static_cast<unsigned>(value);
+        }
+    };
+
+    template <typename FormatArg>
+    static unsigned visit_dynamic_width_arg(const FormatArg & arg)
+    {
+#    if FMT_VERSION >= 120000
+        return arg.visit(dynamic_width_visitor{});
+#    else
+        return fmt::visit_format_arg(dynamic_width_visitor{}, arg);
+#    endif
     }
 
     template <typename FormatContext>
@@ -5958,9 +6034,12 @@ struct formatter<gint::integer<Bits, Signed>>
         }
 
         std::string text = prefix + digits;
-        if (width > text.size())
+        unsigned resolved_width = width;
+        if (dynamic_width_arg_id >= 0)
+            resolved_width = visit_dynamic_width_arg(ctx.arg(dynamic_width_arg_id));
+        if (resolved_width > text.size())
         {
-            const size_t padding = width - text.size();
+            const size_t padding = resolved_width - text.size();
             if (align == '<')
             {
                 text.append(padding, fill);

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -5947,7 +5947,7 @@ struct formatter<gint::integer<Bits, Signed>>
                 prefix = " ";
         }
 
-        if (alternate && digits != "0")
+        if (alternate && (digits != "0" || base == 16 || base == 2))
         {
             if (base == 16)
                 prefix += uppercase ? "0X" : "0x";

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <ios>
 #include <limits>
 #include <ostream>
 #include <stdexcept>
@@ -1365,6 +1366,12 @@ GINT_FORCE_INLINE void mul_limb<4>(uint64_t * lhs, uint64_t rhs) noexcept
 //=== String and stream declarations =========================================
 template <size_t Bits, typename Signed>
 std::string to_string(const integer<Bits, Signed> & value);
+
+namespace detail
+{
+template <size_t Bits, typename Signed>
+std::string to_base_string(const integer<Bits, Signed> & value, unsigned base, bool uppercase);
+}
 
 template <size_t Bits, typename Signed>
 integer<Bits, Signed> from_string(const std::string & text, unsigned base = 0);
@@ -3368,6 +3375,7 @@ public:
     GINT_CONSTEXPR14 friend integer operator+(const integer & v) noexcept { return v; }
 
     friend std::string to_string<>(const integer & v);
+    friend std::string detail::to_base_string<>(const integer & v, unsigned base, bool uppercase);
 
 private:
     template <typename T, typename std::enable_if<detail::is_integral<T>::value, int>::type = 0>
@@ -5636,6 +5644,114 @@ inline void detect_parse_base(const std::string & text, size_t & pos, unsigned &
     else if (base == 2 && pos + 1 < text.size() && text[pos] == '0' && (text[pos + 1] == 'b' || text[pos + 1] == 'B'))
         pos += 2;
 }
+
+inline char format_digit(unsigned digit, bool uppercase) noexcept
+{
+    return static_cast<char>((digit < 10) ? ('0' + digit) : ((uppercase ? 'A' : 'a') + (digit - 10)));
+}
+
+inline size_t stream_prefix_size(const std::string & text) noexcept
+{
+    if (text.empty())
+        return 0;
+    if (text[0] == '-' || text[0] == '+')
+        return 1;
+    if (text.size() >= 2 && text[0] == '0' && (text[1] == 'x' || text[1] == 'X'))
+        return 2;
+    return 0;
+}
+
+inline std::ostream & write_formatted_string(std::ostream & out, const std::string & text)
+{
+    const std::streamsize width = out.width(0);
+    const std::streamsize size = static_cast<std::streamsize>(text.size());
+    if (width <= size)
+        return out.write(text.data(), size);
+
+    const std::streamsize padding = width - size;
+    const char fill = out.fill();
+    const std::ios_base::fmtflags adjust = out.flags() & std::ios_base::adjustfield;
+    const size_t prefix = (adjust == std::ios_base::internal) ? stream_prefix_size(text) : 0;
+
+    if (adjust == std::ios_base::left)
+    {
+        out.write(text.data(), size);
+        for (std::streamsize i = 0; i < padding; ++i)
+            out.put(fill);
+        return out;
+    }
+
+    if (prefix)
+        out.write(text.data(), static_cast<std::streamsize>(prefix));
+    for (std::streamsize i = 0; i < padding; ++i)
+        out.put(fill);
+    out.write(text.data() + prefix, size - static_cast<std::streamsize>(prefix));
+    return out;
+}
+
+template <size_t Bits, typename Signed>
+inline std::string to_base_string(const integer<Bits, Signed> & value, unsigned base, bool uppercase)
+{
+    if (base == 10)
+        return to_string(value);
+
+    const unsigned bits_per_digit = (base == 16) ? 4 : 3;
+    const unsigned mask = (1u << bits_per_digit) - 1u;
+    const size_t digit_count = (Bits + bits_per_digit - 1) / bits_per_digit;
+    std::string out;
+    out.reserve(digit_count);
+
+    bool seen = false;
+    for (size_t digit_index = digit_count; digit_index-- > 0;)
+    {
+        const size_t bit = digit_index * bits_per_digit;
+        const size_t limb_index = bit / 64;
+        const unsigned shift = static_cast<unsigned>(bit % 64);
+        unsigned digit = static_cast<unsigned>((value.data_[limb_index] >> shift) & mask);
+        if (shift + bits_per_digit > 64 && limb_index + 1 < integer<Bits, Signed>::limbs)
+            digit |= static_cast<unsigned>(value.data_[limb_index + 1] << (64 - shift)) & mask;
+
+        const unsigned valid_bits = static_cast<unsigned>((Bits - bit < bits_per_digit) ? (Bits - bit) : bits_per_digit);
+        digit &= (1u << valid_bits) - 1u;
+
+        if (digit || seen)
+        {
+            out.push_back(format_digit(digit, uppercase));
+            seen = true;
+        }
+    }
+
+    return seen ? out : std::string("0");
+}
+
+template <size_t Bits, typename Signed>
+inline std::string format_stream_value(const integer<Bits, Signed> & value, const std::ios_base::fmtflags flags)
+{
+    const std::ios_base::fmtflags basefield = flags & std::ios_base::basefield;
+    const bool uppercase = (flags & std::ios_base::uppercase) != 0;
+    unsigned base = 10;
+    if (basefield == std::ios_base::hex)
+        base = 16;
+    else if (basefield == std::ios_base::oct)
+        base = 8;
+
+    std::string text = to_base_string(value, base, uppercase);
+    if (base == 10)
+    {
+        if ((flags & std::ios_base::showpos) && (text.empty() || text[0] != '-'))
+            text.insert(text.begin(), '+');
+        return text;
+    }
+
+    if ((flags & std::ios_base::showbase) && text != "0")
+    {
+        if (base == 16)
+            text.insert(0, uppercase ? "0X" : "0x");
+        else if (base == 8 && text[0] != '0')
+            text.insert(text.begin(), '0');
+    }
+    return text;
+}
 } // namespace detail
 
 template <size_t Bits, typename Signed>
@@ -5695,7 +5811,8 @@ inline Int from_string(const char * text, unsigned base)
 template <size_t Bits, typename Signed>
 inline std::ostream & operator<<(std::ostream & out, const integer<Bits, Signed> & value)
 {
-    return out << to_string(value);
+    const std::string text = detail::format_stream_value(value, out.flags());
+    return detail::write_formatted_string(out, text);
 } // LCOV_EXCL_LINE
 
 } // namespace gint
@@ -5706,16 +5823,158 @@ namespace fmt
 template <size_t Bits, typename Signed>
 struct formatter<gint::integer<Bits, Signed>>
 {
+    char fill = ' ';
+    char align = '>';
+    char sign = 0;
+    bool alternate = false;
+    unsigned width = 0;
+    char presentation = 0;
+
     template <typename ParseContext>
-    constexpr auto parse(ParseContext & ctx) -> typename ParseContext::iterator
+    auto parse(ParseContext & ctx) -> typename ParseContext::iterator
     {
-        return ctx.begin();
+        auto it = ctx.begin();
+        const auto end = ctx.end();
+        if (it == end || *it == '}')
+            return it;
+
+        auto next = it;
+        ++next;
+        if (next != end && (*next == '<' || *next == '>' || *next == '^' || *next == '='))
+        {
+            fill = *it;
+            align = *next;
+            it = next;
+            ++it;
+        }
+        else if (*it == '<' || *it == '>' || *it == '^' || *it == '=')
+        {
+            align = *it;
+            ++it;
+        }
+
+        if (it != end && (*it == '+' || *it == '-' || *it == ' '))
+        {
+            sign = *it;
+            ++it;
+        }
+
+        if (it != end && *it == '#')
+        {
+            alternate = true;
+            ++it;
+        }
+
+        if (it != end && *it == '0')
+        {
+            if (align == '>')
+            {
+                align = '=';
+                fill = '0';
+            }
+            ++it;
+        }
+
+        while (it != end && *it >= '0' && *it <= '9')
+        {
+            width = width * 10u + static_cast<unsigned>(*it - '0');
+            ++it;
+        }
+
+        if (it != end && *it != '}')
+        {
+            presentation = *it;
+            if (presentation != 'd' && presentation != 'x' && presentation != 'X' && presentation != 'o')
+                throw fmt::format_error("invalid format specifier for gint::integer");
+            ++it;
+        }
+
+        if (it != end && *it != '}')
+            throw fmt::format_error("invalid format specifier for gint::integer");
+        return it;
     }
 
     template <typename FormatContext>
     auto format(const gint::integer<Bits, Signed> & value, FormatContext & ctx) const -> typename FormatContext::iterator
     {
-        return fmt::format_to(ctx.out(), "{}", gint::to_string(value));
+        using Int = gint::integer<Bits, Signed>;
+        unsigned base = 10;
+        bool uppercase = false;
+        if (presentation == 'x' || presentation == 'X')
+        {
+            base = 16;
+            uppercase = (presentation == 'X');
+        }
+        else if (presentation == 'o')
+        {
+            base = 8;
+        }
+
+        const bool negative = std::is_same<Signed, signed>::value && value < Int(0);
+        std::string prefix;
+        std::string digits;
+        if (base == 10)
+        {
+            digits = gint::to_string(value);
+            if (!digits.empty() && digits[0] == '-')
+            {
+                prefix = "-";
+                digits.erase(digits.begin());
+            }
+        }
+        else
+        {
+            const Int magnitude = negative ? -value : value;
+            digits = gint::detail::to_base_string(magnitude, base, uppercase);
+            if (negative)
+                prefix = "-";
+        }
+
+        if (prefix.empty())
+        {
+            if (sign == '+')
+                prefix = "+";
+            else if (sign == ' ')
+                prefix = " ";
+        }
+
+        if (alternate && digits != "0")
+        {
+            if (base == 16)
+                prefix += uppercase ? "0X" : "0x";
+            else if (base == 8 && digits[0] != '0')
+                prefix += "0";
+        }
+
+        std::string text = prefix + digits;
+        if (width > text.size())
+        {
+            const size_t padding = width - text.size();
+            if (align == '<')
+            {
+                text.append(padding, fill);
+            }
+            else if (align == '^')
+            {
+                const size_t left = padding / 2;
+                const size_t right = padding - left;
+                text.insert(0, left, fill);
+                text.append(right, fill);
+            }
+            else if (align == '=' && !prefix.empty())
+            {
+                text = prefix + std::string(padding, fill) + digits;
+            }
+            else
+            {
+                text.insert(0, padding, fill);
+            }
+        }
+
+        auto out = ctx.out();
+        for (size_t i = 0; i < text.size(); ++i)
+            *out++ = text[i];
+        return out;
     } // LCOV_EXCL_LINE
 };
 } // namespace fmt

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -5695,7 +5695,7 @@ inline std::string to_base_string(const integer<Bits, Signed> & value, unsigned 
     if (base == 10)
         return to_string(value);
 
-    const unsigned bits_per_digit = (base == 16) ? 4 : 3;
+    const unsigned bits_per_digit = (base == 16) ? 4 : (base == 8) ? 3 : 1;
     const unsigned mask = (1u << bits_per_digit) - 1u;
     const size_t digit_count = (Bits + bits_per_digit - 1) / bits_per_digit;
     std::string out;
@@ -5887,7 +5887,8 @@ struct formatter<gint::integer<Bits, Signed>>
         if (it != end && *it != '}')
         {
             presentation = *it;
-            if (presentation != 'd' && presentation != 'x' && presentation != 'X' && presentation != 'o')
+            if (presentation != 'd' && presentation != 'x' && presentation != 'X' && presentation != 'o' && presentation != 'b'
+                && presentation != 'B')
                 throw fmt::format_error("invalid format specifier for gint::integer");
             ++it;
         }
@@ -5911,6 +5912,11 @@ struct formatter<gint::integer<Bits, Signed>>
         else if (presentation == 'o')
         {
             base = 8;
+        }
+        else if (presentation == 'b' || presentation == 'B')
+        {
+            base = 2;
+            uppercase = (presentation == 'B');
         }
 
         const bool negative = std::is_same<Signed, signed>::value && value < Int(0);
@@ -5945,6 +5951,8 @@ struct formatter<gint::integer<Bits, Signed>>
         {
             if (base == 16)
                 prefix += uppercase ? "0X" : "0x";
+            else if (base == 2)
+                prefix += uppercase ? "0B" : "0b";
             else if (base == 8 && digits[0] != '0')
                 prefix += "0";
         }

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -5831,7 +5831,7 @@ struct formatter<gint::integer<Bits, Signed>>
     char presentation = 0;
 
     template <typename ParseContext>
-    auto parse(ParseContext & ctx) -> typename ParseContext::iterator
+    FMT_CONSTEXPR auto parse(ParseContext & ctx) -> typename ParseContext::iterator
     {
         auto it = ctx.begin();
         const auto end = ctx.end();

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -5867,6 +5867,9 @@ struct formatter<gint::integer<Bits, Signed>>
 
         if (it != end && *it == '0')
         {
+#    if FMT_VERSION < 120000
+            fill = '0';
+#    endif
             if (align == '>')
             {
                 align = '=';

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -10,6 +10,7 @@
 #include <functional>
 #include <ios>
 #include <limits>
+#include <locale>
 #include <ostream>
 #include <stdexcept>
 #include <string>
@@ -5825,12 +5826,14 @@ struct formatter<gint::integer<Bits, Signed>>
 {
     char fill = ' ';
     char align = '>';
+    bool explicit_align = false;
     char sign = 0;
     bool alternate = false;
     unsigned width = 0;
     int dynamic_width_arg_id = -1;
     basic_string_view<char> dynamic_width_arg_name;
     bool dynamic_width_is_named = false;
+    bool localized = false;
     char presentation = 0;
 
     static FMT_CONSTEXPR bool is_name_start(char ch) { return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || ch == '_'; }
@@ -5845,18 +5848,19 @@ struct formatter<gint::integer<Bits, Signed>>
         if (it == end || *it == '}')
             return it;
 
-        bool explicit_align = false;
         auto next = it;
         ++next;
-        if (next != end && (*next == '<' || *next == '>' || *next == '^' || *next == '='))
+        if (next != end && (*next == '<' || *next == '>' || *next == '^'))
         {
+            if (*it == '{' || *it == '}')
+                throw fmt::format_error("invalid fill character");
             fill = *it;
             align = *next;
             explicit_align = true;
             it = next;
             ++it;
         }
-        else if (*it == '<' || *it == '>' || *it == '^' || *it == '=')
+        else if (*it == '<' || *it == '>' || *it == '^')
         {
             align = *it;
             explicit_align = true;
@@ -5865,6 +5869,8 @@ struct formatter<gint::integer<Bits, Signed>>
 
         if (it != end && (*it == '+' || *it == '-' || *it == ' '))
         {
+            if (std::is_same<Signed, unsigned>::value)
+                throw fmt::format_error("invalid format specifier for gint::integer");
             sign = *it;
             ++it;
         }
@@ -5893,7 +5899,10 @@ struct formatter<gint::integer<Bits, Signed>>
 
         while (it != end && *it >= '0' && *it <= '9')
         {
-            width = width * 10u + static_cast<unsigned>(*it - '0');
+            const unsigned digit = static_cast<unsigned>(*it - '0');
+            if (width > ((std::numeric_limits<unsigned>::max)() - digit) / 10u)
+                throw fmt::format_error("number is too big");
+            width = width * 10u + digit;
             ++it;
         }
 
@@ -5925,7 +5934,10 @@ struct formatter<gint::integer<Bits, Signed>>
                 while (it != end && *it >= '0' && *it <= '9')
                 {
                     has_arg_id = true;
-                    arg_id = arg_id * 10 + static_cast<int>(*it - '0');
+                    const int digit = static_cast<int>(*it - '0');
+                    if (arg_id > ((std::numeric_limits<int>::max)() - digit) / 10)
+                        throw fmt::format_error("number is too big");
+                    arg_id = arg_id * 10 + digit;
                     ++it;
                 }
                 if (!has_arg_id || it == end || *it != '}')
@@ -5936,11 +5948,17 @@ struct formatter<gint::integer<Bits, Signed>>
             }
         }
 
+        if (it != end && *it == 'L')
+        {
+            localized = true;
+            ++it;
+        }
+
         if (it != end && *it != '}')
         {
             presentation = *it;
             if (presentation != 'd' && presentation != 'x' && presentation != 'X' && presentation != 'o' && presentation != 'b'
-                && presentation != 'B')
+                && presentation != 'B' && presentation != 'c')
                 throw fmt::format_error("invalid format specifier for gint::integer");
             ++it;
         }
@@ -5993,6 +6011,52 @@ struct formatter<gint::integer<Bits, Signed>>
 #    endif
     }
 
+    template <typename LocaleRef>
+    static void apply_locale_grouping(std::string & digits, LocaleRef loc)
+    {
+#    if !defined(FMT_USE_LOCALE) || FMT_USE_LOCALE
+        const std::locale locale = loc.template get<std::locale>();
+        const std::numpunct<char> & punct = std::use_facet<std::numpunct<char>>(locale);
+        const std::string grouping = punct.grouping();
+        if (grouping.empty() || digits.size() < 2)
+            return;
+
+        const char separator = punct.thousands_sep();
+        std::string grouped;
+        grouped.reserve(digits.size() + digits.size() / 3);
+
+        size_t end = digits.size();
+        size_t grouping_index = 0;
+        while (end > 0)
+        {
+            const unsigned char group_size = static_cast<unsigned char>(grouping[grouping_index]);
+            if (group_size == 0 || group_size == static_cast<unsigned char>((std::numeric_limits<char>::max)()))
+                break;
+            if (group_size >= end)
+                break;
+
+            const size_t begin = end - group_size;
+            if (!grouped.empty())
+                grouped.insert(grouped.begin(), separator);
+            grouped.insert(0, digits, begin, group_size);
+            end = begin;
+            if (grouping_index + 1 < grouping.size())
+                ++grouping_index;
+        }
+
+        if (end > 0)
+        {
+            if (!grouped.empty())
+                grouped.insert(grouped.begin(), separator);
+            grouped.insert(0, digits, 0, end);
+        }
+        digits.swap(grouped);
+#    else
+        (void)digits;
+        (void)loc;
+#    endif
+    }
+
     template <typename FormatContext>
     auto format(const gint::integer<Bits, Signed> & value, FormatContext & ctx) const -> typename FormatContext::iterator
     {
@@ -6017,7 +6081,12 @@ struct formatter<gint::integer<Bits, Signed>>
         const bool negative = std::is_same<Signed, signed>::value && value < Int(0);
         std::string prefix;
         std::string digits;
-        if (base == 10)
+        if (presentation == 'c')
+        {
+            const Int magnitude = negative ? -value : value;
+            digits.assign(1, static_cast<char>(static_cast<unsigned char>(magnitude)));
+        }
+        else if (base == 10)
         {
             digits = gint::to_string(value);
             if (!digits.empty() && digits[0] == '-')
@@ -6034,7 +6103,15 @@ struct formatter<gint::integer<Bits, Signed>>
                 prefix = "-";
         }
 
-        if (prefix.empty())
+        const bool use_localized_digits = localized && presentation != 'c'
+#    if FMT_VERSION < 120000
+            && base == 10
+#    endif
+            ;
+        if (use_localized_digits)
+            apply_locale_grouping(digits, ctx.locale());
+
+        if (presentation != 'c' && prefix.empty())
         {
             if (sign == '+')
                 prefix = "+";
@@ -6042,7 +6119,7 @@ struct formatter<gint::integer<Bits, Signed>>
                 prefix = " ";
         }
 
-        if (alternate && (digits != "0" || base == 16 || base == 2))
+        if (presentation != 'c' && alternate && (digits != "0" || base == 16 || base == 2))
         {
             if (base == 16)
                 prefix += uppercase ? "0X" : "0x";
@@ -6061,18 +6138,19 @@ struct formatter<gint::integer<Bits, Signed>>
         if (resolved_width > text.size())
         {
             const size_t padding = resolved_width - text.size();
-            if (align == '<')
+            const char effective_align = (presentation == 'c' && !explicit_align && align == '>') ? '<' : align;
+            if (effective_align == '<')
             {
                 text.append(padding, fill);
             }
-            else if (align == '^')
+            else if (effective_align == '^')
             {
                 const size_t left = padding / 2;
                 const size_t right = padding - left;
                 text.insert(0, left, fill);
                 text.append(right, fill);
             }
-            else if (align == '=' && !prefix.empty())
+            else if (effective_align == '=' && !use_localized_digits && !prefix.empty())
             {
                 text = prefix + std::string(padding, fill) + digits;
             }

--- a/tests/fmt_support_test.cpp
+++ b/tests/fmt_support_test.cpp
@@ -81,6 +81,8 @@ TEST(fmt_support, format_integer_width_and_alternate_specs)
     EXPECT_EQ(fmt::format("{:{}x}", U128(42), 6), "    2a");
     EXPECT_EQ(fmt::format("{0:>{1}}", U128(42), 6), "    42");
     EXPECT_EQ(fmt::format("{:0>{}}", U128(42), 6), "000042");
+    EXPECT_EQ(fmt::format("{:{w}}", U128(42), fmt::arg("w", 6)), "    42");
+    EXPECT_EQ(fmt::format("{:>{w}}", U128(42), fmt::arg("w", 6)), "    42");
 }
 
 TEST(fmt_support, format_signed_integer_base_specs)

--- a/tests/fmt_support_test.cpp
+++ b/tests/fmt_support_test.cpp
@@ -45,6 +45,8 @@ TEST(fmt_support, format_integer_base_specs)
     EXPECT_EQ(fmt::format("{:x}", value), "10000000000000002a");
     EXPECT_EQ(fmt::format("{:X}", value), "10000000000000002A");
     EXPECT_EQ(fmt::format("{:o}", U128(71)), "107");
+    EXPECT_EQ(fmt::format("{:b}", U128(42)), "101010");
+    EXPECT_EQ(fmt::format("{:B}", U128(42)), "101010");
     EXPECT_EQ(fmt::format("{:d}", value), "295147905179352825898");
 }
 
@@ -53,8 +55,11 @@ TEST(fmt_support, format_integer_width_and_alternate_specs)
     using U128 = gint::integer<128, unsigned>;
 
     EXPECT_EQ(fmt::format("{:#X}", U128(42)), "0X2A");
+    EXPECT_EQ(fmt::format("{:#b}", U128(42)), "0b101010");
+    EXPECT_EQ(fmt::format("{:#B}", U128(42)), "0B101010");
     EXPECT_EQ(fmt::format("{:08x}", U128(42)), "0000002a");
     EXPECT_EQ(fmt::format("{:#08x}", U128(42)), "0x00002a");
+    EXPECT_EQ(fmt::format("{:#010b}", U128(42)), "0b00101010");
     EXPECT_EQ(fmt::format("{:>6d}", U128(42)), "    42");
     EXPECT_EQ(fmt::format("{:<6d}", U128(42)), "42    ");
     EXPECT_EQ(fmt::format("{:^6d}", U128(42)), "  42  ");
@@ -75,5 +80,6 @@ TEST(fmt_support, format_signed_integer_base_specs)
     const S128 value = -42;
 
     EXPECT_EQ(fmt::format("{:x}", value), "-2a");
+    EXPECT_EQ(fmt::format("{:#b}", value), "-0b101010");
     EXPECT_EQ(fmt::format("{:#08x}", value), "-0x0002a");
 }

--- a/tests/fmt_support_test.cpp
+++ b/tests/fmt_support_test.cpp
@@ -58,6 +58,15 @@ TEST(fmt_support, format_integer_width_and_alternate_specs)
     EXPECT_EQ(fmt::format("{:>6d}", U128(42)), "    42");
     EXPECT_EQ(fmt::format("{:<6d}", U128(42)), "42    ");
     EXPECT_EQ(fmt::format("{:^6d}", U128(42)), "  42  ");
+#if FMT_VERSION < 120000
+    EXPECT_EQ(fmt::format("{:<08d}", U128(42)), "42000000");
+    EXPECT_EQ(fmt::format("{:^08d}", U128(42)), "00042000");
+    EXPECT_EQ(fmt::format("{:x<08d}", U128(42)), "42000000");
+#else
+    EXPECT_EQ(fmt::format("{:<08d}", U128(42)), "42      ");
+    EXPECT_EQ(fmt::format("{:^08d}", U128(42)), "   42   ");
+    EXPECT_EQ(fmt::format("{:x<08d}", U128(42)), "42xxxxxx");
+#endif
 }
 
 TEST(fmt_support, format_signed_integer_base_specs)

--- a/tests/fmt_support_test.cpp
+++ b/tests/fmt_support_test.cpp
@@ -4,8 +4,19 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <locale>
 #include <utility>
 #include <vector>
+
+namespace
+{
+class comma_numpunct : public std::numpunct<char>
+{
+    char do_thousands_sep() const override { return ','; }
+
+    std::string do_grouping() const override { return "\3"; }
+};
+}
 
 TEST(fmt_support, format_gint)
 {
@@ -47,6 +58,8 @@ TEST(fmt_support, format_integer_base_specs)
     EXPECT_EQ(fmt::format("{:o}", U128(71)), "107");
     EXPECT_EQ(fmt::format("{:b}", U128(42)), "101010");
     EXPECT_EQ(fmt::format("{:B}", U128(42)), "101010");
+    EXPECT_EQ(fmt::format("{:c}", U128(65)), fmt::format("{:c}", 65));
+    EXPECT_EQ(fmt::format("{:c}", U128(321)), fmt::format("{:c}", 321));
     EXPECT_EQ(fmt::format("{:d}", value), "295147905179352825898");
 }
 
@@ -83,6 +96,28 @@ TEST(fmt_support, format_integer_width_and_alternate_specs)
     EXPECT_EQ(fmt::format("{:0>{}}", U128(42), 6), "000042");
     EXPECT_EQ(fmt::format("{:{w}}", U128(42), fmt::arg("w", 6)), "    42");
     EXPECT_EQ(fmt::format("{:>{w}}", U128(42), fmt::arg("w", 6)), "    42");
+    EXPECT_EQ(fmt::format("{:4c}", U128(65)), fmt::format("{:4c}", 65));
+    EXPECT_EQ(fmt::format("{:>4c}", U128(65)), fmt::format("{:>4c}", 65));
+    EXPECT_EQ(fmt::format("{:^4c}", U128(65)), fmt::format("{:^4c}", 65));
+    EXPECT_EQ(fmt::format("{:08c}", U128(65)), fmt::format("{:08c}", 65));
+    EXPECT_EQ(fmt::format("{:L}", U128(42)), fmt::format("{:L}", 42u));
+    EXPECT_EQ(fmt::format("{:Ld}", U128(42)), fmt::format("{:Ld}", 42u));
+    EXPECT_EQ(fmt::format("{:Lx}", U128(42)), fmt::format("{:Lx}", 42u));
+    EXPECT_EQ(fmt::format("{:#Lx}", U128(42)), fmt::format("{:#Lx}", 42u));
+    EXPECT_THROW(static_cast<void>(fmt::format(fmt::runtime("{:{>8d}"), U128(42))), fmt::format_error);
+    EXPECT_THROW(static_cast<void>(fmt::format(fmt::runtime("{:999999999999999999999999999999999999d}"), U128(42))), fmt::format_error);
+    EXPECT_THROW(static_cast<void>(fmt::format(fmt::runtime("{:>{999999999999999999999999999999999999}}"), U128(42))), fmt::format_error);
+}
+
+TEST(fmt_support, reject_unsigned_integer_sign_specs)
+{
+    using U128 = gint::integer<128, unsigned>;
+
+    EXPECT_THROW(static_cast<void>(fmt::format(fmt::runtime("{:+d}"), U128(42))), fmt::format_error);
+    EXPECT_THROW(static_cast<void>(fmt::format(fmt::runtime("{: d}"), U128(42))), fmt::format_error);
+    EXPECT_THROW(static_cast<void>(fmt::format(fmt::runtime("{:-d}"), U128(42))), fmt::format_error);
+    EXPECT_THROW(static_cast<void>(fmt::format(fmt::runtime("{:+x}"), U128(42))), fmt::format_error);
+    EXPECT_THROW(static_cast<void>(fmt::format(fmt::runtime("{:+c}"), U128(42))), fmt::format_error);
 }
 
 TEST(fmt_support, format_signed_integer_base_specs)
@@ -96,4 +131,31 @@ TEST(fmt_support, format_signed_integer_base_specs)
     EXPECT_EQ(fmt::format("{:08d}", value), fmt::format("{:08d}", -42));
     EXPECT_EQ(fmt::format("{:>08d}", value), fmt::format("{:>08d}", -42));
     EXPECT_EQ(fmt::format("{:>{}}", value, 6), fmt::format("{:>{}}", -42, 6));
+    EXPECT_EQ(fmt::format("{:c}", value), fmt::format("{:c}", -42));
+    EXPECT_EQ(fmt::format("{:4c}", value), fmt::format("{:4c}", -42));
+    EXPECT_EQ(fmt::format("{:L}", value), fmt::format("{:L}", -42));
+    EXPECT_EQ(fmt::format("{:Ld}", value), fmt::format("{:Ld}", -42));
+    EXPECT_EQ(fmt::format("{:#Lx}", value), fmt::format("{:#Lx}", -42));
+    EXPECT_THROW(static_cast<void>(fmt::format(fmt::runtime("{:=8d}"), value)), fmt::format_error);
+    EXPECT_THROW(static_cast<void>(fmt::format(fmt::runtime("{:0=8d}"), value)), fmt::format_error);
+}
+
+TEST(fmt_support, format_integer_locale_specs)
+{
+    using U128 = gint::integer<128, unsigned>;
+    using S128 = gint::integer<128, signed>;
+    const std::locale locale(std::locale::classic(), new comma_numpunct);
+
+    EXPECT_EQ(fmt::format(locale, "{:L}", U128(1234567)), fmt::format(locale, "{:L}", 1234567u));
+    EXPECT_EQ(fmt::format(locale, "{:Ld}", U128(1234567)), fmt::format(locale, "{:Ld}", 1234567u));
+    EXPECT_EQ(fmt::format(locale, "{:Lx}", U128(0x12d687)), fmt::format(locale, "{:Lx}", 0x12d687u));
+    EXPECT_EQ(fmt::format(locale, "{:#Lx}", U128(0x12d687)), fmt::format(locale, "{:#Lx}", 0x12d687u));
+    EXPECT_EQ(fmt::format(locale, "{:Lo}", U128(01234567)), fmt::format(locale, "{:Lo}", 01234567u));
+    EXPECT_EQ(fmt::format(locale, "{:Lb}", U128(0x12d687)), fmt::format(locale, "{:Lb}", 0x12d687u));
+    EXPECT_EQ(fmt::format(locale, "{:014L}", U128(1234567)), fmt::format(locale, "{:014L}", 1234567u));
+    EXPECT_EQ(fmt::format(locale, "{:014L}", S128(-1234567)), fmt::format(locale, "{:014L}", -1234567));
+    EXPECT_EQ(fmt::format(locale, "{:+014L}", S128(1234567)), fmt::format(locale, "{:+014L}", 1234567));
+    EXPECT_EQ(fmt::format(locale, "{: 014L}", S128(1234567)), fmt::format(locale, "{: 014L}", 1234567));
+    EXPECT_EQ(fmt::format(locale, "{:#014Lx}", S128(0x12d687)), fmt::format(locale, "{:#014Lx}", 0x12d687));
+    EXPECT_EQ(fmt::format(locale, "{:#014Lx}", S128(-0x12d687)), fmt::format(locale, "{:#014Lx}", -0x12d687));
 }

--- a/tests/fmt_support_test.cpp
+++ b/tests/fmt_support_test.cpp
@@ -36,3 +36,35 @@ TEST(fmt_support, format_signed_gint)
     gint::integer<128, signed> value{-42};
     EXPECT_EQ(fmt::format("{}", value), "-42");
 }
+
+TEST(fmt_support, format_integer_base_specs)
+{
+    using U128 = gint::integer<128, unsigned>;
+    const U128 value = (U128(1) << 68) + U128(0x2a);
+
+    EXPECT_EQ(fmt::format("{:x}", value), "10000000000000002a");
+    EXPECT_EQ(fmt::format("{:X}", value), "10000000000000002A");
+    EXPECT_EQ(fmt::format("{:o}", U128(71)), "107");
+    EXPECT_EQ(fmt::format("{:d}", value), "295147905179352825898");
+}
+
+TEST(fmt_support, format_integer_width_and_alternate_specs)
+{
+    using U128 = gint::integer<128, unsigned>;
+
+    EXPECT_EQ(fmt::format("{:#X}", U128(42)), "0X2A");
+    EXPECT_EQ(fmt::format("{:08x}", U128(42)), "0000002a");
+    EXPECT_EQ(fmt::format("{:#08x}", U128(42)), "0x00002a");
+    EXPECT_EQ(fmt::format("{:>6d}", U128(42)), "    42");
+    EXPECT_EQ(fmt::format("{:<6d}", U128(42)), "42    ");
+    EXPECT_EQ(fmt::format("{:^6d}", U128(42)), "  42  ");
+}
+
+TEST(fmt_support, format_signed_integer_base_specs)
+{
+    using S128 = gint::integer<128, signed>;
+    const S128 value = -42;
+
+    EXPECT_EQ(fmt::format("{:x}", value), "-2a");
+    EXPECT_EQ(fmt::format("{:#08x}", value), "-0x0002a");
+}

--- a/tests/fmt_support_test.cpp
+++ b/tests/fmt_support_test.cpp
@@ -77,6 +77,10 @@ TEST(fmt_support, format_integer_width_and_alternate_specs)
     EXPECT_EQ(fmt::format("{:^08d}", U128(42)), "   42   ");
     EXPECT_EQ(fmt::format("{:x<08d}", U128(42)), "42xxxxxx");
 #endif
+    EXPECT_EQ(fmt::format("{:>{}}", U128(42), 6), "    42");
+    EXPECT_EQ(fmt::format("{:{}x}", U128(42), 6), "    2a");
+    EXPECT_EQ(fmt::format("{0:>{1}}", U128(42), 6), "    42");
+    EXPECT_EQ(fmt::format("{:0>{}}", U128(42), 6), "000042");
 }
 
 TEST(fmt_support, format_signed_integer_base_specs)
@@ -87,4 +91,7 @@ TEST(fmt_support, format_signed_integer_base_specs)
     EXPECT_EQ(fmt::format("{:x}", value), "-2a");
     EXPECT_EQ(fmt::format("{:#b}", value), "-0b101010");
     EXPECT_EQ(fmt::format("{:#08x}", value), "-0x0002a");
+    EXPECT_EQ(fmt::format("{:08d}", value), fmt::format("{:08d}", -42));
+    EXPECT_EQ(fmt::format("{:>08d}", value), fmt::format("{:>08d}", -42));
+    EXPECT_EQ(fmt::format("{:>{}}", value, 6), fmt::format("{:>{}}", -42, 6));
 }

--- a/tests/fmt_support_test.cpp
+++ b/tests/fmt_support_test.cpp
@@ -57,6 +57,11 @@ TEST(fmt_support, format_integer_width_and_alternate_specs)
     EXPECT_EQ(fmt::format("{:#X}", U128(42)), "0X2A");
     EXPECT_EQ(fmt::format("{:#b}", U128(42)), "0b101010");
     EXPECT_EQ(fmt::format("{:#B}", U128(42)), "0B101010");
+    EXPECT_EQ(fmt::format("{:#x}", U128(0)), "0x0");
+    EXPECT_EQ(fmt::format("{:#X}", U128(0)), "0X0");
+    EXPECT_EQ(fmt::format("{:#b}", U128(0)), "0b0");
+    EXPECT_EQ(fmt::format("{:#B}", U128(0)), "0B0");
+    EXPECT_EQ(fmt::format("{:#o}", U128(0)), "0");
     EXPECT_EQ(fmt::format("{:08x}", U128(42)), "0000002a");
     EXPECT_EQ(fmt::format("{:#08x}", U128(42)), "0x00002a");
     EXPECT_EQ(fmt::format("{:#010b}", U128(42)), "0b00101010");

--- a/tests/stream_test.cpp
+++ b/tests/stream_test.cpp
@@ -1,3 +1,4 @@
+#include <iomanip>
 #include <sstream>
 #include <gint/gint.h>
 #include <gtest/gtest.h>
@@ -24,6 +25,61 @@ TEST(WideIntegerStream, OutputZero)
     std::ostringstream oss;
     oss << v;
     EXPECT_EQ(oss.str(), "0");
+}
+
+TEST(WideIntegerStream, HonorsIntegerBaseFlags)
+{
+    using U128 = gint::integer<128, unsigned>;
+    const U128 value = (U128(1) << 68) + U128(0x2a);
+
+    {
+        std::ostringstream oss;
+        oss << std::hex << value;
+        EXPECT_EQ(oss.str(), "10000000000000002a");
+    }
+
+    {
+        std::ostringstream oss;
+        oss << std::showbase << std::uppercase << std::hex << value;
+        EXPECT_EQ(oss.str(), "0X10000000000000002A");
+    }
+
+    {
+        std::ostringstream oss;
+        oss << std::oct << U128(71);
+        EXPECT_EQ(oss.str(), "107");
+    }
+}
+
+TEST(WideIntegerStream, FormatsSignedNegativeHexAsBitPattern)
+{
+    gint::integer<128, signed> value = -42;
+    std::ostringstream oss;
+    oss << std::hex << value;
+    EXPECT_EQ(oss.str(), "ffffffffffffffffffffffffffffffd6");
+}
+
+TEST(WideIntegerStream, HonorsWidthFillAndSigns)
+{
+    using U128 = gint::integer<128, unsigned>;
+
+    {
+        std::ostringstream oss;
+        oss << std::showpos << U128(42);
+        EXPECT_EQ(oss.str(), "+42");
+    }
+
+    {
+        std::ostringstream oss;
+        oss << std::showbase << std::hex << std::internal << std::setw(8) << std::setfill('0') << U128(42);
+        EXPECT_EQ(oss.str(), "0x00002a");
+    }
+
+    {
+        std::ostringstream oss;
+        oss << std::left << std::setw(5) << U128(42);
+        EXPECT_EQ(oss.str(), "42   ");
+    }
 }
 
 TEST(WideIntegerStream, OutputAdditionalWidths)


### PR DESCRIPTION
## 问题
- `operator<<` 对 `std::hex` / `std::oct` / `showbase` / `uppercase` 等整数流格式标志没有响应，只输出十进制。
- fmt formatter 只接受空 spec，`{:x}` 等常见整数格式会失败。

## 做了什么
- 为 stream 输出增加 base-aware 格式化，支持十进制、十六进制、八进制、`showbase`、`uppercase`、`showpos`、`setw`、`setfill` 和 `internal` padding。
- 为 fmt formatter 增加常用整数 spec：`d`、`x`、`X`、`o`、`#`、`0`、宽度和基本对齐。
- 增加 stream/fmt 回归测试，覆盖 base flags、前缀、大小写、宽度填充和有符号负数。

## 验证
- 本机 AppleClang 全量单元测试通过。
- Docker/GCC 全量单元测试通过。
- 本机 AppleClang `ToString/` 同口径基准对比：主干约 104 ns，当前分支约 103 ns，无可见性能回退。

## 风险
- 中低。变更集中在格式化输出路径，不改变算术、比较、除法或十进制 `to_string` 算法。
- stream 的非十进制有符号负数按固定位宽补码位型输出；fmt 的非十进制有符号负数按带负号的数值格式输出，分别贴近各自接口习惯。