### PR TITLE
fix: add string parsing support

### DIFF
--- a/docs/TECH_SPEC.md
+++ b/docs/TECH_SPEC.md
@@ -89,6 +89,7 @@
 ## 10. 字符串、流与格式化
 
 - `gint::to_string()`：十进制字符串表示；负数以 `-` 前缀。
+- `gint::from_string()` 与显式字符串构造：按给定位宽解析字符串；默认自动识别十进制、`0x`/`0X` 十六进制、`0b`/`0B` 二进制和前导 `0` 八进制，也可显式传入 2..36 的进制。结果按固定宽度累积，超出位宽时按模 `2^Bits` 包裹；无效输入抛出 `std::invalid_argument`。
 - `operator<<`：输出十进制表示。
 - `fmt` 支持：定义 `GINT_ENABLE_FMT` 宏后，提供 `fmt::formatter<gint::integer<...>>`。
 

--- a/include/gint/gint.h
+++ b/include/gint/gint.h
@@ -1381,6 +1381,18 @@ template <size_t Bits, typename Signed>
 std::string to_string(const integer<Bits, Signed> & value);
 
 template <size_t Bits, typename Signed>
+integer<Bits, Signed> from_string(const std::string & text, unsigned base = 0);
+
+template <size_t Bits, typename Signed>
+integer<Bits, Signed> from_string(const char * text, unsigned base = 0);
+
+template <typename Int>
+Int from_string(const std::string & text, unsigned base = 0);
+
+template <typename Int>
+Int from_string(const char * text, unsigned base = 0);
+
+template <size_t Bits, typename Signed>
 std::ostream & operator<<(std::ostream & out, const integer<Bits, Signed> & value);
 
 //=== Core integer type ======================================================
@@ -1491,6 +1503,10 @@ public:
         assign_float(v);
     }
 
+    explicit integer(const std::string & text) { *this = from_string<Bits, Signed>(text); }
+
+    explicit integer(const char * text) { *this = from_string<Bits, Signed>(text); }
+
 private:
     template <size_t OtherBits, typename OtherSigned, size_t... I>
     constexpr integer(const integer<OtherBits, OtherSigned> & other, detail::index_sequence<I...>) noexcept
@@ -1566,6 +1582,18 @@ public:
     integer & operator=(T v) noexcept
     {
         assign_float(v);
+        return *this;
+    }
+
+    integer & operator=(const std::string & text)
+    {
+        *this = from_string<Bits, Signed>(text);
+        return *this;
+    }
+
+    integer & operator=(const char * text)
+    {
+        *this = from_string<Bits, Signed>(text);
         return *this;
     }
 
@@ -5574,6 +5602,108 @@ inline std::string to_string(const integer<Bits, Signed> & v)
     if (neg)
         out.insert(out.begin(), '-');
     return out;
+}
+
+namespace detail
+{
+inline unsigned string_digit_value(char c) noexcept
+{
+    if (c >= '0' && c <= '9')
+        return static_cast<unsigned>(c - '0');
+    if (c >= 'a' && c <= 'z')
+        return static_cast<unsigned>(c - 'a') + 10u;
+    if (c >= 'A' && c <= 'Z')
+        return static_cast<unsigned>(c - 'A') + 10u;
+    return 36u;
+}
+
+inline void detect_parse_base(const std::string & text, size_t & pos, unsigned & base)
+{
+    if (base != 0 && (base < 2 || base > 36))
+        throw std::invalid_argument("gint::from_string invalid base");
+
+    if (base == 0)
+    {
+        if (pos + 1 < text.size() && text[pos] == '0' && (text[pos + 1] == 'x' || text[pos + 1] == 'X'))
+        {
+            base = 16;
+            pos += 2;
+        }
+        else if (pos + 1 < text.size() && text[pos] == '0' && (text[pos + 1] == 'b' || text[pos + 1] == 'B'))
+        {
+            base = 2;
+            pos += 2;
+        }
+        else if (pos + 1 < text.size() && text[pos] == '0')
+        {
+            base = 8;
+        }
+        else
+        {
+            base = 10;
+        }
+        return;
+    }
+
+    if (base == 16 && pos + 1 < text.size() && text[pos] == '0' && (text[pos + 1] == 'x' || text[pos + 1] == 'X'))
+        pos += 2;
+    else if (base == 2 && pos + 1 < text.size() && text[pos] == '0' && (text[pos + 1] == 'b' || text[pos + 1] == 'B'))
+        pos += 2;
+}
+} // namespace detail
+
+template <size_t Bits, typename Signed>
+inline integer<Bits, Signed> from_string(const std::string & text, unsigned base)
+{
+    if (text.empty())
+        throw std::invalid_argument("gint::from_string empty string");
+
+    size_t pos = 0;
+    bool negative = false;
+    if (text[pos] == '+' || text[pos] == '-')
+    {
+        negative = text[pos] == '-';
+        ++pos;
+        if (pos == text.size())
+            throw std::invalid_argument("gint::from_string sign without digits");
+    }
+
+    detail::detect_parse_base(text, pos, base);
+    if (pos == text.size())
+        throw std::invalid_argument("gint::from_string prefix without digits");
+
+    integer<Bits, Signed> result = 0;
+    const integer<Bits, Signed> wide_base = base;
+    for (; pos < text.size(); ++pos)
+    {
+        const unsigned digit = detail::string_digit_value(text[pos]);
+        if (digit >= base)
+            throw std::invalid_argument("gint::from_string invalid digit");
+        result *= wide_base;
+        result += integer<Bits, Signed>(digit);
+    }
+
+    return negative ? -result : result;
+}
+
+template <size_t Bits, typename Signed>
+inline integer<Bits, Signed> from_string(const char * text, unsigned base)
+{
+    if (!text)
+        throw std::invalid_argument("gint::from_string null string");
+    return from_string<Bits, Signed>(std::string(text), base);
+}
+
+template <typename Int>
+inline Int from_string(const std::string & text, unsigned base)
+{
+    return from_string<Int::bits, typename Int::signed_tag>(text, base);
+}
+
+template <typename Int>
+inline Int from_string(const char * text, unsigned base)
+{
+    return from_string<Int::bits, typename Int::signed_tag>(text, base);
 }
 
 template <size_t Bits, typename Signed>

--- a/tests/conversion_test.cpp
+++ b/tests/conversion_test.cpp
@@ -14,6 +14,9 @@ static_assert(std::is_constructible<gint::Int128, gint::UInt128>::value, "UInt12
 static_assert(std::is_constructible<gint::UInt256, gint::Int128>::value, "Int128 should explicitly construct UInt256");
 static_assert(!std::is_convertible<gint::UInt128, gint::Int128>::value, "integer signedness conversion should stay explicit");
 static_assert(std::is_assignable<gint::Int256 &, gint::UInt128>::value, "UInt128 should assign to Int256 explicitly");
+static_assert(std::is_constructible<gint::UInt128, const char *>::value, "UInt128 should be constructible from string literals");
+static_assert(std::is_constructible<gint::UInt128, std::string>::value, "UInt128 should be constructible from std::string");
+static_assert(!std::is_convertible<const char *, gint::UInt128>::value, "string construction should be explicit");
 
 #if __cplusplus >= 201402L
 constexpr bool constexpr_integer_conversion_works()
@@ -262,6 +265,55 @@ TEST(WideIntegerConversion, ToStringZero)
 {
     EXPECT_EQ(gint::to_string(gint::integer<128, unsigned>(0)), "0");
     EXPECT_EQ(gint::to_string(gint::integer<128, signed>(0)), "0");
+}
+
+TEST(WideIntegerConversion, FromStringDecimal)
+{
+    const auto max_u128 = gint::from_string<gint::UInt128>("340282366920938463463374607431768211455");
+    EXPECT_EQ(max_u128, std::numeric_limits<gint::UInt128>::max());
+
+    const auto min_s128 = gint::from_string<gint::Int128>("-170141183460469231731687303715884105728");
+    EXPECT_EQ(min_s128, std::numeric_limits<gint::Int128>::min());
+    EXPECT_EQ(gint::to_string(min_s128), "-170141183460469231731687303715884105728");
+}
+
+TEST(WideIntegerConversion, FromStringPrefixesAndBases)
+{
+    EXPECT_EQ((gint::from_string<128, unsigned>("0xffffffffffffffffffffffffffffffff")), std::numeric_limits<gint::UInt128>::max());
+    EXPECT_EQ(gint::from_string<gint::UInt128>("0b101010"), gint::UInt128(42));
+    EXPECT_EQ(gint::from_string<gint::UInt128>("0107"), gint::UInt128(71));
+    EXPECT_EQ(gint::from_string<gint::UInt128>("ff", 16), gint::UInt128(255));
+    EXPECT_EQ(gint::from_string<gint::UInt128>("0xff", 16), gint::UInt128(255));
+}
+
+TEST(WideIntegerConversion, FromStringWrapsToFixedWidth)
+{
+    EXPECT_EQ(gint::from_string<gint::UInt128>("340282366920938463463374607431768211456"), gint::UInt128(0));
+    EXPECT_EQ(gint::from_string<gint::UInt128>("-1"), std::numeric_limits<gint::UInt128>::max());
+}
+
+TEST(WideIntegerConversion, StringConstructorsAndAssignments)
+{
+    gint::UInt256 value("12345678901234567890");
+    EXPECT_EQ(gint::to_string(value), "12345678901234567890");
+
+    gint::UInt256 assigned;
+    assigned = std::string("0x10000000000000000");
+    EXPECT_EQ(assigned, gint::UInt256(1) << 64);
+
+    assigned = "0b1001";
+    EXPECT_EQ(assigned, gint::UInt256(9));
+}
+
+TEST(WideIntegerConversion, FromStringRejectsInvalidInput)
+{
+    EXPECT_THROW(gint::from_string<gint::UInt128>(""), std::invalid_argument);
+    EXPECT_THROW(gint::from_string<gint::UInt128>("-"), std::invalid_argument);
+    EXPECT_THROW(gint::from_string<gint::UInt128>("0x"), std::invalid_argument);
+    EXPECT_THROW(gint::from_string<gint::UInt128>("12z", 10), std::invalid_argument);
+    EXPECT_THROW(gint::from_string<gint::UInt128>("2", 2), std::invalid_argument);
+    EXPECT_THROW(gint::from_string<gint::UInt128>("123", 1), std::invalid_argument);
+    EXPECT_THROW((gint::from_string<128, unsigned>(nullptr)), std::invalid_argument);
 }
 
 TEST(WideIntegerConversion, FloatingDivisionBothWays)


### PR DESCRIPTION
## 问题
- 库只有 `to_string`，没有 `from_string` 或字符串构造，用户需要手工逐 limb 拼接字符串输入。

## 做了什么
- 新增 `gint::from_string<Bits, Signed>(...)` 和 `gint::from_string<Int>(...)` 两类调用形式。
- 新增显式 `std::string` / `const char*` 构造与赋值。
- 默认自动识别十进制、`0x`/`0X`、`0b`/`0B` 和前导 `0` 八进制；也支持显式 2..36 进制。
- 解析按固定宽度累积，超宽自然 wrap；非法输入抛 `std::invalid_argument`。
- 更新 TECH_SPEC，并增加十进制边界、前缀进制、wrap、构造/赋值和非法输入测试。

## 验证
- 本机 AppleClang 全量单元测试通过。
- Docker/GCC 全量单元测试通过。
- 本机 AppleClang 常用算术和 `ToString/` 同口径基准抽查：算术项持平；`ToString/` 加长重跑后主干和当前分支均约 106 ns CPU，无可见性能回退。

## 风险
- 中低。新增解析 API 复用现有固定宽度算术语义，不改变已有算术、比较、除法或 `to_string` 实现。
- 字符串构造是 explicit，避免字符串字面量隐式参与混合运算。