### PR TITLE
fix: harden ci validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
     branches: ["**"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -126,6 +129,23 @@ jobs:
         with:
           name: coverage-info
           path: runs/ci/coverage.info
+
+  sanitizers:
+    name: sanitizers (ubuntu-clang)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cmake build-essential clang \
+            libfmt-dev libgtest-dev
+      - name: Configure
+        run: CXX=clang++ cmake -S . -B runs/ci/build-sanitizers -DENABLE_SANITIZERS=ON -DGINT_BUILD_TESTS=ON -DGINT_BUILD_TESTS_RELEASE=OFF -DGINT_BUILD_BENCHMARKS=OFF
+      - name: Build
+        run: cmake --build runs/ci/build-sanitizers --config Debug --parallel
+      - name: Run tests
+        run: ctest --test-dir runs/ci/build-sanitizers --output-on-failure
 
   format:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(gint LANGUAGES CXX)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 option(ENABLE_COVERAGE "Enable coverage reporting" OFF)
+option(ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer for tests" OFF)
 option(GINT_BUILD_TESTS "Build test suite" ON)
 option(GINT_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(GINT_BUILD_TESTS_CXX17 "Build C++17 test suite (gint_tests_cxx17)" OFF)
@@ -18,6 +19,16 @@ if(ENABLE_COVERAGE)
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         list(APPEND GINT_TEST_OPTIONS --coverage)
         set(GINT_TEST_LINK_OPTIONS --coverage)
+    endif()
+endif()
+
+if(ENABLE_SANITIZERS)
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        list(APPEND GINT_TEST_OPTIONS -fsanitize=address,undefined -fno-omit-frame-pointer)
+        list(APPEND GINT_TEST_LINK_OPTIONS -fsanitize=address,undefined)
+    else()
+        message(FATAL_ERROR "ENABLE_SANITIZERS requires GCC or Clang")
     endif()
 endif()
 
@@ -55,6 +66,7 @@ if(GINT_BUILD_TESTS)
         tests/float_interop_edge_test.cpp
         tests/fmt_support_test.cpp
         tests/numeric_limits_test.cpp
+        tests/property_test.cpp
         tests/shift_test.cpp
         tests/stream_test.cpp
     )

--- a/tests/property_test.cpp
+++ b/tests/property_test.cpp
@@ -1,0 +1,153 @@
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <gint/gint.h>
+#include <gtest/gtest.h>
+
+namespace
+{
+class DeterministicRng
+{
+public:
+    explicit DeterministicRng(uint64_t seed)
+        : state_(seed)
+    {
+    }
+
+    uint64_t next() noexcept
+    {
+        uint64_t x = state_;
+        x ^= x << 7;
+        x ^= x >> 9;
+        x ^= x << 8;
+        state_ = x;
+        return x;
+    }
+
+private:
+    uint64_t state_;
+};
+
+std::string to_decimal(unsigned __int128 value)
+{
+    if (value == 0)
+        return "0";
+
+    char buf[64];
+    unsigned pos = 64;
+    while (value)
+    {
+        buf[--pos] = static_cast<char>('0' + (value % 10));
+        value /= 10;
+    }
+    return std::string(buf + pos, 64 - pos);
+}
+
+gint::UInt256 random_u256(DeterministicRng & rng)
+{
+    gint::UInt256 value = rng.next();
+    for (unsigned i = 0; i < 3; ++i)
+    {
+        value <<= 64;
+        value += gint::UInt256(rng.next());
+    }
+    return value;
+}
+
+gint::Int256 random_s256(DeterministicRng & rng)
+{
+    gint::Int256 value = gint::Int256(rng.next() & 0xffffu);
+    for (unsigned i = 0; i < 2; ++i)
+    {
+        value <<= 64;
+        value += gint::Int256(rng.next());
+    }
+    return (rng.next() & 1u) ? -value : value;
+}
+
+gint::Int256 abs_s256(gint::Int256 value)
+{
+    return value < gint::Int256(0) ? -value : value;
+}
+}
+
+TEST(WideIntegerProperty, UInt128MatchesNativeArithmetic)
+{
+    DeterministicRng rng(0x9e3779b97f4a7c15ULL);
+    for (unsigned i = 0; i < 4096; ++i)
+    {
+        const unsigned __int128 a = (static_cast<unsigned __int128>(rng.next()) << 64) | rng.next();
+        unsigned __int128 b = (static_cast<unsigned __int128>(rng.next()) << 64) | rng.next();
+        if (b == 0)
+            b = 1;
+
+        const gint::UInt128 ga = a;
+        const gint::UInt128 gb = b;
+
+        EXPECT_TRUE(static_cast<unsigned __int128>(ga + gb) == a + b);
+        EXPECT_TRUE(static_cast<unsigned __int128>(ga - gb) == a - b);
+        EXPECT_TRUE(static_cast<unsigned __int128>(ga * gb) == a * b);
+        EXPECT_TRUE(static_cast<unsigned __int128>(ga / gb) == a / b);
+        EXPECT_TRUE(static_cast<unsigned __int128>(ga % gb) == a % b);
+        EXPECT_EQ(gint::to_string(ga), to_decimal(a));
+    }
+}
+
+TEST(WideIntegerProperty, Int128MatchesNativeSmallSignedArithmetic)
+{
+    DeterministicRng rng(0x243f6a8885a308d3ULL);
+    for (unsigned i = 0; i < 4096; ++i)
+    {
+        const int64_t a = static_cast<int64_t>(rng.next());
+        int64_t b = static_cast<int64_t>(rng.next());
+        if (b == 0 || (a == std::numeric_limits<int64_t>::min() && b == -1))
+            b = 1;
+
+        const gint::Int128 ga = a;
+        const gint::Int128 gb = b;
+
+        EXPECT_TRUE(static_cast<__int128>(ga + gb) == static_cast<__int128>(a) + static_cast<__int128>(b));
+        EXPECT_TRUE(static_cast<__int128>(ga - gb) == static_cast<__int128>(a) - static_cast<__int128>(b));
+        EXPECT_TRUE(static_cast<__int128>(ga * gb) == static_cast<__int128>(a) * static_cast<__int128>(b));
+        EXPECT_TRUE(static_cast<__int128>(ga / gb) == static_cast<__int128>(a / b));
+        EXPECT_TRUE(static_cast<__int128>(ga % gb) == static_cast<__int128>(a % b));
+    }
+}
+
+TEST(WideIntegerProperty, UInt256DivModIdentity)
+{
+    DeterministicRng rng(0x13198a2e03707344ULL);
+    for (unsigned i = 0; i < 2048; ++i)
+    {
+        const gint::UInt256 dividend = random_u256(rng);
+        gint::UInt256 divisor = random_u256(rng);
+        if (divisor == gint::UInt256(0))
+            divisor = 1;
+
+        const gint::UInt256 quotient = dividend / divisor;
+        const gint::UInt256 remainder = dividend % divisor;
+
+        EXPECT_EQ(quotient * divisor + remainder, dividend);
+        EXPECT_LT(remainder, divisor);
+    }
+}
+
+TEST(WideIntegerProperty, Int256DivModIdentityAndRemainderSign)
+{
+    DeterministicRng rng(0xa4093822299f31d0ULL);
+    for (unsigned i = 0; i < 2048; ++i)
+    {
+        const gint::Int256 dividend = random_s256(rng);
+        gint::Int256 divisor = random_s256(rng);
+        if (divisor == gint::Int256(0))
+            divisor = 7;
+
+        const gint::Int256 quotient = dividend / divisor;
+        const gint::Int256 remainder = dividend % divisor;
+
+        EXPECT_EQ(quotient * divisor + remainder, dividend);
+        EXPECT_LT(abs_s256(remainder), abs_s256(divisor));
+        if (remainder != gint::Int256(0))
+            EXPECT_EQ(remainder < gint::Int256(0), dividend < gint::Int256(0));
+    }
+}


### PR DESCRIPTION
## 问题
- CI 只在 push 上触发，fork/branch PR 场景不会自动跑验证。
- 没有 sanitizer job 覆盖手写 limb 运算、intrinsics 和边界操作。
- 缺少确定性 property tests 来反复覆盖算术恒等式和 128 位 native 交叉校验。

## 做了什么
- CI 增加 `pull_request` 和 `workflow_dispatch` 触发。
- 新增 `ENABLE_SANITIZERS` CMake 选项，并在 CI 加入 ubuntu-clang ASan/UBSan job。
- 新增确定性 property tests：
  - `UInt128` 与原生 `unsigned __int128` 的 add/sub/mul/div/mod/to_string 交叉校验。
  - `Int128` 与原生小范围 signed 算术交叉校验。
  - `UInt256` / `Int256` div/mod 恒等式、余数范围和 signed remainder 符号规则。

## 验证
- 本机 AppleClang 全量单元测试通过。
- 本机 AppleClang sanitizer 配置全量通过。
- Docker/GCC 全量单元测试通过。

## 性能
- 本次只改 CI/CMake 和测试源，不改变发布头文件实现或 benchmark 可执行的生产路径；无运行时性能影响。

## 风险
- 低。主要风险是 CI 时间增加；sanitizer job 关闭 Release/O3 测试目标，只跑 Debug sanitizer，控制运行成本。