### PR TITLE
docs: refresh project documentation and license

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,8 @@
    - `breaking-change.md`：`break: <简要描述>`
    - 默认模板：`<类型>: <简要描述>`，其中 `<类型>` 必须来自上面的类型集合。
 3. 必须使用 PR 模板：
-   - 使用 `.github/PULL_REQUEST_TEMPLATE/` 下的模板创建 PR。
+   - 默认模板为 `.github/pull_request_template.md`；专用模板位于 `.github/PULL_REQUEST_TEMPLATE/`。
+   - 创建 PR 时必须套用默认模板或最合适的专用模板。
    - 请选择最合适的专用模板：`feature.md`、`bugfix.md`、`perf.md`、`refactor.md`、`docs.md`、`breaking-change.md`。
    - 若不属于以上任一类别，再使用默认模板。
    - PR 正文只保留与本次变更直接相关的信息；删除空段落、占位符和不适用项，避免把流程说明留在正文里。

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,11 @@ RUN git clone --depth 1 --branch release-1.10.0 https://github.com/google/google
      && cmake --install /tmp/googletest/build \
      && rm -rf /tmp/googletest
 
-# ---- 安装 Google Benchmark v1.8.3（仍以 C++11 构建）----
+# ---- 安装 Google Benchmark v1.9.5（benchmark 工具链使用 C++17；库本体仍以 C++11 验证）----
 # 关闭其自测/依赖，避免不必要的 GTest/LibPFM 约束；安装共享库与 CMake config
-RUN git clone --depth 1 --branch v1.8.3 https://github.com/google/benchmark.git /tmp/benchmark \
+RUN git clone --depth 1 --branch v1.9.5 https://github.com/google/benchmark.git /tmp/benchmark \
      && cmake -S /tmp/benchmark -B /tmp/benchmark/build \
-     -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=11 \
+     -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 \
      -DBENCHMARK_ENABLE_TESTING=OFF -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
      -DBENCHMARK_ENABLE_LIBPFM=OFF -DBUILD_SHARED_LIBS=ON \
      && cmake --build /tmp/benchmark/build -j"$(nproc)" \

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but not
+limited to compiled object code, generated documentation, and
+conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work (an
+example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the
+original version of the Work and any modifications or additions to
+that Work or Derivative Works thereof, that is intentionally submitted
+to Licensor for inclusion in the Work by the copyright owner or by an
+individual or Legal Entity authorized to submit on behalf of the
+copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of, publicly
+display, publicly perform, sublicense, and distribute the Work and
+such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Do not include
+the brackets!) The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2026 KodiakAS and contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -13,28 +13,28 @@ Co-maintained by me and **OpenAI Codex** — with a little inspiration from a hi
 
 ## Performance
 
-Local AppleClang microbenchmark sample: Apple M4 Pro, macOS 26.4.1, AppleClang 21.0.0, Release/O3, Google Benchmark (`--benchmark_min_time=0.2s`). Numbers are `real_time` ns/op (lower is better) for hot, in-cache operator throughput on fixed 256-bit inputs. Use them for same-toolchain regression tracking; Docker/GCC and real workload results should be reported separately.
+Local AppleClang microbenchmark sample (commit `eae8c0b`, collected 2026-06-11): Apple M4 Pro, macOS 26.5.1, AppleClang 21.0.0, Release/O3, Google Benchmark v1.9.5 (`BENCH_BITS=256 --gint_full --benchmark_min_time=0.2s`). Numbers are `real_time` ns/op (lower is better) for hot, in-cache operator throughput on fixed 256-bit inputs. Use them for same-toolchain regression tracking; Docker/GCC and real workload results should be reported separately.
 
 Arithmetic & ToString — 256-bit
 
 | Case                   | gint | ClickHouse | Boost |
 | ---------------------- | ---: | ---------: | ----: |
-| Add/NoCarry            | 0.677 |       1.84 |  4.90 |
-| Add/FullCarry          | 0.682 |       2.07 |  1.91 |
-| Sub/NoBorrow           | 0.683 |       1.63 |  4.99 |
-| Sub/FullBorrow         | 0.686 |       1.82 |  2.09 |
-| Mul/U64xU64            | 1.86 |       2.89 |  2.34 |
-| Mul/HighxHigh          | 1.83 |       2.85 | 10.7 |
-| Div/SmallDivisor32     | 11.5 |       14.7 | 20.8 |
-| Div/Pow2Divisor        | 6.00 |        316 | 68.8 |
-| Div/SimilarMagnitude   | 13.4 |        237 | 69.3 |
-| ToString/Base10        |  128 |        298 |  148 |
+| Add/NoCarry            | 0.666 |       1.11 |  4.37 |
+| Add/FullCarry          | 0.695 |       1.62 |  1.88 |
+| Sub/NoBorrow           | 0.691 |      0.944 |  4.38 |
+| Sub/FullBorrow         | 0.691 |       1.62 |  1.52 |
+| Mul/U64xU64            | 1.80 |       1.89 |  2.28 |
+| Mul/HighxHigh          | 1.83 |       2.79 | 11.5 |
+| Div/SmallDivisor32     | 10.8 |       14.0 | 20.2 |
+| Div/Pow2Divisor        | 4.85 |        310 | 67.4 |
+| Div/SimilarMagnitude   | 13.0 |        226 | 68.0 |
+| ToString/Base10        |  106 |        294 |  146 |
 
 Highlights
-- Add/Sub: ~2.4-3.0x faster vs ClickHouse; ~2.8-7.3x vs Boost.
-- Mul: faster than ClickHouse and Boost on the listed 256-bit cases, with the largest gain on high x high.
+- Add/Sub: faster than ClickHouse on the listed cases by ~1.4-2.3x, and faster than Boost by ~2.2-6.6x.
+- Mul: slightly faster on U64 x U64 and materially faster on high x high.
 - Div: large wins for power-of-two and similar-magnitude divisors; still faster on 32-bit small divisors.
-- ToString: ~1.1x faster vs Boost; ~2.3x vs ClickHouse.
+- ToString: ~1.4x faster vs Boost; ~2.8x vs ClickHouse.
 
 Full matrices and methodology: see `docs/BENCHMARKS.md`.
 
@@ -85,14 +85,19 @@ image with `COVERAGE_DIR=runs/docker/build-coverage`.
 
 - Technical spec: `docs/TECH_SPEC.md`
 - Benchmarks: `docs/BENCHMARKS.md`
+- Validation environments: `docs/VALIDATION_ENVIRONMENTS.md`
+
+## License
+
+Apache License 2.0. See `LICENSE`.
 
 ## Development Environment
 
 A dedicated Dockerfile sets up a CentOS 8 Linux/GCC validation environment
 with all build dependencies preinstalled. It also installs `clang`/`clangd`
-for development tooling, but unless `CC`/`CXX` is explicitly overridden, CMake
-uses GCC/g++ inside the container. The repository's `Makefile` provides a
-target to build this image:
+for development tooling and Google Benchmark v1.9.5 for benchmark binaries.
+Unless `CC`/`CXX` is explicitly overridden, CMake uses GCC/g++ inside the
+container. The repository's `Makefile` provides a target to build this image:
 
 ```bash
 make image

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -2,7 +2,7 @@
 
 本文档介绍性能测试结构：
 - **基准测试（Benchmark）**：仅编译并运行 gint 的用例，用于观察绝对性能。
-- **对比测试（Comparison）**：在同一套用例上，对比 ClickHouse 宽整数与 Boost.Multiprecision 的 256 位算术。
+- **对比测试（Comparison）**：在同一套用例上，按所选 `BENCH_BITS` 对比 gint、ClickHouse 宽整数与 Boost.Multiprecision；覆盖算术、取模、位运算、移位与字符串转换等用例。
 
 ## 环境口径
 
@@ -12,12 +12,13 @@
 - 不同架构、OS、编译器结果应分别呈现，不直接混合横向比较。
 - 可复现验证环境的初始化方式见 [验证环境固化](VALIDATION_ENVIRONMENTS.md)。该文档只固化当前环境依赖，不固定具体测试项目、过滤器或位宽。
 
-## 本机 AppleClang 样本（历史示例）
-- 采集平台：Apple M4 Pro，macOS 26.4.1，arm64
+## 本机 AppleClang 样本（commit `eae8c0b`）
+- 采集时间：2026-06-11
+- 采集平台：Apple M4 Pro，macOS 26.5.1，arm64
 - 核心数：12
 - 工具链：AppleClang 21.0.0，Google Benchmark v1.9.5
 - 编译：Release（`-O3 -DNDEBUG`）
-- 参数：`--benchmark_min_time=0.2s`
+- 参数：`BENCH_BITS=256 --gint_full --benchmark_min_time=0.2s`
 - 备注：macOS 上可能无法设置线程亲和性，Google Benchmark 的警告不影响相对对比。
 
 ## 通用提示
@@ -47,7 +48,7 @@
 ## 对比测试（Comparison）
 
 ### 目的
-- 在代表性细分场景下，对比 256 位算术在不同实现（gint/ClickHouse/Boost）间的性能差异。
+- 在代表性细分场景下，对比所选位宽在不同实现（gint/ClickHouse/Boost）间的性能差异；默认位宽为 256，可通过 `BENCH_BITS` 切换到 `128/512/1024`。
 
 ### 用法
 - 本机 AppleClang 标准矩阵：`make bench-compare BENCH_ARGS="--benchmark_min_time=0.2s"`
@@ -67,7 +68,7 @@
 
 ### 结果（完整矩阵，real_time ns/op）
 
-数值越低越好。以下数据来自 `bench-compare-full` 的本机 AppleClang 样本；如需复现，应按上文命令重新采集当前工作区的本地结果。
+数值越低越好。以下数据来自 `bench-compare-full` 的本机 AppleClang 256-bit 样本（commit `eae8c0b`）；如需复现，应按上文命令重新采集当前工作区的本地结果。
 
 #### 加法（Addition）
 
@@ -78,9 +79,9 @@
 
 | 用例         | gint  | ClickHouse | Boost |
 | ------------ | ----: | ---------: | ----: |
-| NoCarry      | 0.677 |       1.84 |  4.90 |
-| FullCarry    | 0.682 |       2.07 |  1.91 |
-| CarryChain64 | 0.683 |       1.81 |  4.84 |
+| NoCarry      | 0.666 |       1.11 |  4.37 |
+| FullCarry    | 0.695 |       1.62 |  1.88 |
+| CarryChain64 | 0.688 |       1.15 |  4.33 |
 
 #### 减法（Subtraction）
 
@@ -91,9 +92,9 @@
 
 | 用例          | gint  | ClickHouse | Boost |
 | ------------- | ----: | ---------: | ----: |
-| NoBorrow      | 0.683 |       1.63 |  4.99 |
-| FullBorrow    | 0.686 |       1.82 |  2.09 |
-| BorrowChain64 | 0.681 |       1.67 |  4.91 |
+| NoBorrow      | 0.691 |      0.944 |  4.38 |
+| FullBorrow    | 0.691 |       1.62 |  1.52 |
+| BorrowChain64 | 0.690 |       1.18 |  4.15 |
 
 #### 乘法（Multiplication）
 
@@ -105,10 +106,10 @@
 
 | 用例         | gint  | ClickHouse | Boost |
 | ------------ | ----: | ---------: | ----: |
-| U64xU64      |  1.86 |       2.89 |  2.34 |
-| HighxHigh    |  1.83 |       2.85 |  10.7 |
-| WideTimesU64 | 0.932 |       3.36 |  2.35 |
-| U32xWide     |  1.92 |       3.82 |  4.37 |
+| U64xU64      | 1.80 |       1.89 |  2.28 |
+| HighxHigh    | 1.83 |       2.79 |  11.5 |
+| WideTimesU64 | 1.53 |       3.29 |  2.52 |
+| U32xWide     | 1.80 |       2.40 |  3.65 |
 
 #### 除法（Division）
 
@@ -122,12 +123,12 @@
 
 | 用例                       | gint | ClickHouse | Boost |
 | -------------------------- | ---: | ---------: | ----: |
-| SmallDivisor32（32 位）    | 11.5 |       14.7 |  20.8 |
-| SmallDivisor64（64 位）    | 14.1 |       14.6 |  23.6 |
-| Pow2Divisor（2 的幂）      | 6.00 |        316 |  68.8 |
-| SimilarMagnitude           | 13.4 |        237 |  69.3 |
-| LargeDivisor128（两 limb） | 18.2 |        564 |  37.0 |
-| SimilarMagnitude2          | 9.99 |        217 |  83.6 |
+| SmallDivisor32（32 位）    | 10.8 |       14.0 |  20.2 |
+| SmallDivisor64（64 位）    | 13.5 |       13.5 |  21.9 |
+| Pow2Divisor（2 的幂）      | 4.85 |        310 |  67.4 |
+| SimilarMagnitude           | 13.0 |        226 |  68.0 |
+| LargeDivisor128（两 limb） | 18.1 |        546 |  37.1 |
+| SimilarMagnitude2          | 9.91 |        208 |  81.7 |
 
 #### 取模（Modulo）
 
@@ -137,8 +138,8 @@
 
 | 用例             | gint | ClickHouse | Boost |
 | ---------------- | ---: | ---------: | ----: |
-| SmallDivisor64   | 13.1 |       16.1 |  20.7 |
-| SimilarMagnitude | 16.8 |        237 |  68.8 |
+| SmallDivisor64   | 11.7 |       15.0 |  20.5 |
+| SimilarMagnitude | 16.7 |        227 |  67.5 |
 
 #### 位运算（Bitwise）
 
@@ -148,8 +149,8 @@
 
 | 用例 | gint  | ClickHouse | Boost |
 | ---- | ----: | ---------: | ----: |
-| And  | 0.779 |      0.778 |  7.64 |
-| Xor  | 0.782 |      0.364 |  7.62 |
+| And  | 0.364 |      0.379 |  6.57 |
+| Xor  | 0.360 |      0.430 |  7.07 |
 
 #### 移位（Shift）
 
@@ -159,8 +160,8 @@
 
 | 用例          | gint | ClickHouse | Boost |
 | ------------- | ---: | ---------: | ----: |
-| LeftVariable  | 1.90 |       3.35 |  6.00 |
-| RightVariable | 1.39 |       3.22 |  3.86 |
+| LeftVariable  | 1.31 |       3.36 |  5.67 |
+| RightVariable | 1.35 |       3.07 |  3.26 |
 
 #### 字符串转换（ToString）
 
@@ -169,4 +170,4 @@
 
 | 用例   | gint | ClickHouse | Boost |
 | ------ | ---: | ---------: | ----: |
-| Base10 |  128 |        298 |   148 |
+| Base10 |  106 |        294 |   146 |

--- a/docs/TECH_SPEC.md
+++ b/docs/TECH_SPEC.md
@@ -7,6 +7,7 @@
 - 高性能：针对常见位宽与路径做了专门优化（如 128/256 位乘除）
 - 良好互操作性：与原生整数、`__int128`、浮点数进行双向转换与混合运算（浮点混合算术经截断，见“浮点互操作”）
 - 可选的运行时检查：按需开启除零检查
+- 标准库集成：提供 `std::numeric_limits` 与 `std::hash` 专用化
 
 
 ## 2. 核心类型与模板参数
@@ -62,17 +63,17 @@
 
 ## 8. 移位运算
 
-- 左/右移：`<<`, `>>` 及其复合赋值，位移量类型为 `int`。
+- 左/右移：`<<`, `>>` 及其复合赋值；位移量支持内建整数类型以及 `__int128`/`unsigned __int128`。
 - 语义：
-  - 位移量 <= 0：不改变（no-op）。
+  - 位移量为 0：不改变（no-op）。
+  - 有符号位移量 < 0：不改变（no-op）。
   - 位移量 >= 位宽：
     - 左移：结果为零。
     - 右移：无符号为零；有符号按算术右移填充（负数为 -1，非负为 0）。
 - 右移：
   - `Signed = signed` 时为算术右移（符号扩展）。
   - `Signed = unsigned` 时为逻辑右移（零扩展）。
-- 位移量为负：保持不变（no-op）。
-  - 左移丢弃高位，按模 `2^Bits` 包裹。
+- 左移丢弃高位，按模 `2^Bits` 包裹。
 
 测试参考：`tests/shift_test.cpp`。
 
@@ -90,10 +91,10 @@
 
 - `gint::to_string()`：十进制字符串表示；负数以 `-` 前缀。
 - `gint::from_string()` 与显式字符串构造：按给定位宽解析字符串；默认自动识别十进制、`0x`/`0X` 十六进制、`0b`/`0B` 二进制和前导 `0` 八进制，也可显式传入 2..36 的进制。结果按固定宽度累积，超出位宽时按模 `2^Bits` 包裹；无效输入抛出 `std::invalid_argument`。
-- `operator<<`：输出十进制表示。
-- `fmt` 支持：定义 `GINT_ENABLE_FMT` 宏后，提供 `fmt::formatter<gint::integer<...>>`。
+- `operator<<`：默认输出十进制表示，并遵循 `std::hex`、`std::oct`、`std::showbase`、`std::showpos`、`std::uppercase`、宽度、填充和对齐等 stream 格式标志。
+- `fmt` 支持：定义 `GINT_ENABLE_FMT` 宏后，提供 `fmt::formatter<gint::integer<...>>`，支持十进制、十六进制、八进制、二进制、字符展示、符号、替代格式、宽度、动态宽度和本地化分组等常用整数格式项。
 
-测试参考：`tests/fmt_support_test.cpp`。
+测试参考：`tests/stream_test.cpp`、`tests/fmt_support_test.cpp`。
 
 ## 11. 与原生类型的互操作
 
@@ -106,13 +107,14 @@
 
 测试参考：`tests/conversion_test.cpp`。
 
-## 12. 数值极值与 `numeric_limits` 专用化
+## 12. 数值极值、`numeric_limits` 与 `std::hash`
 
 - `digits = Bits - (is_signed ? 1 : 0)`；`radix = 2`；`is_exact = true`；`is_modulo = true`；`round_style = round_toward_zero`。
 - `min()`：无符号为 0；有符号为最小负值（仅最高位为 1）。
 - `max()`：无符号为全 1；有符号为按补码的最大正值。
+- `std::hash<gint::integer<Bits, Signed>>`：按所有 limb 组合哈希值，满足默认构造与 `noexcept` 调用要求。
 
-测试参考：`tests/numeric_limits_test.cpp`。
+测试参考：`tests/numeric_limits_test.cpp`、`tests/hash_test.cpp`。
 
 ## 13. 异常与错误语义
 
@@ -158,14 +160,14 @@
     - 2 的幂：直接转化为右移得到商、按掩码取余。
   - 2‑limb（128 位）快速路径：`div_128` 基于 `__int128` 进行 128/128→128 的除法，返回 128 位商。
   - 多 limb 除数（一般情况）Knuth 算法 D：
-    - 通用实现 `div_large`：只做一次 128/64 除法并以“乘回求余”代替取模，减少除法使用；规范化左移通过内部工具函数 `lshift_limbs_to()` 复用，消除重复代码。
+    - 通用实现 `div_large`：每个估商步骤只做一次 128/64 除法并以“乘回求余”代替取模，减少除法使用；规范化左移通过内部工具函数 `lshift_limbs_to()` 复用，消除重复代码。
     - 两肢专用 `div_large_2`：定长内核，基于最高 limb 估商，校正最多两次；乘回复用 `qhat*v1 = numerator - rhat` 消去一处乘法。
     - 三肢专用 `div_large_3`：定长内核，复用 `qhat*v[2] = numerator - rhat` 优化；保持 Algorithm D 的估商修正与借位补偿流程。
-    - 四肢专用 `div_large_4`：针对 256 位满宽除数（`divisor_limbs == 4`）且商最多为单 limb 的场景，定长展开规范化、估商修正和乘回减法；`operator/` 与 GCC-tuned 的多 limb `operator%` 路径都会复用该内核。
+    - 四肢专用 `div_large_4`：针对 256 位满宽除数（`divisor_limbs == 4`）且商最多为单 limb 的场景，定长展开规范化、估商修正和乘回减法；`operator/` 使用该内核。x86_64/GCC 的无符号满宽 `operator%` 走直接求余的 `rem_large_4`，避免先生成商再乘回。
 - 字符串转换（to_string）：
   - 采用十进制 10^19 分块法：每次除以 10^19 收集一段 19 位十进制块（低位到高位），最后一次性拼接输出（首块不补零，其余块左零填充）。
   - 相较逐位除以 10 并在字符串头部插入，避免 O(n^2) 内存移动，整体近似 O(n)。
- 
+
 
 ## 16. 浮点互操作
 

--- a/docs/VALIDATION_ENVIRONMENTS.md
+++ b/docs/VALIDATION_ENVIRONMENTS.md
@@ -48,7 +48,7 @@ scripts/bootstrap-validation-env.sh --scope "${SCOPE}"
 脚本做三件事：
 
 - 在 Ubuntu/Debian 上安装基础包，其他系统可用 `--skip-packages` 跳过包安装；
-- 在 `runs/<scope>/deps/` 下为每个编译器构建 Release 版 Google Benchmark；
+- 在 `runs/<scope>/deps/` 下为每个编译器构建 Release 版 Google Benchmark（默认 v1.9.5，可用 `--benchmark-version` 覆盖）；
 - 在 `runs/<scope>/env/` 下生成 env 文件。
 
 脚本不会运行任何项目测试或 benchmark。
@@ -73,7 +73,7 @@ rsync
 tar
 ```
 
-不要依赖发行版 `libbenchmark-dev` 做性能结论；本项目用脚本在 `runs/` 下构建固定版本 Release `google-benchmark`，避免发行版包构建类型污染结果。
+不要依赖发行版 `libbenchmark-dev` 做性能结论；本项目用脚本在 `runs/` 下构建固定版本 Release `google-benchmark`，避免发行版包构建类型污染结果。Google Benchmark v1.9.5 本身按 C++17 工具链构建；这只影响 benchmark 工具二进制，不改变库本体和单元测试的 C++11 兼容性目标。
 
 非 Ubuntu/Debian 且依赖已安装的环境可显式跳过包安装，只构建当前编译器对应的 `google-benchmark`：
 


### PR DESCRIPTION
## 概述

刷新项目文档中已经过期的 benchmark、接口与验证环境说明，并为项目补充 Apache License 2.0。

## 做了什么

- 更新 README 和 benchmark 文档中的本机 AppleClang 256-bit 样本、环境口径和对比测试范围。
- 补齐技术规格中的移位量、stream/fmt 格式化、std::hash 和 full-width modulo 路径说明。
- 同步验证环境与 Dockerfile 中的 Google Benchmark v1.9.5 口径，并修正 PR 模板路径说明。
- 添加 Apache License 2.0。

## 验证

- `git diff --cached --check`
- `docker build --check .`
- `make test`（451/451 passed）
