### PR TITLE
fix: align benchmark comparison value domain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@
     - 可通过 `BENCH_ARGS` 传递 Google Benchmark 参数（示例：`--benchmark_min_time=0.2s`）。
   - 对比测试（Comparison）：在相同用例上对比 ClickHouse 与 Boost。
     - 命令：`make bench-compare`（标准矩阵）/ `make bench-compare-full`（完整矩阵，等价传入 `--gint_full`）。
+    - 三方共享矩阵必须使用能够表示同一数学值的类型与输入：bit-pattern 场景统一使用 unsigned 固定位宽类型；若未来增加 signed comparison，必须从统一数学值构造并在计时前校验三方值相等，禁止把同一 raw words 直接解释为补码 signed 与 signed-magnitude。
 
 - 术语定义
   - 目标用例：指一个或一组“具体 Benchmark 用例”，其命名遵循统一模式：

--- a/README.md
+++ b/README.md
@@ -13,26 +13,26 @@ Co-maintained by me and **OpenAI Codex** — with a little inspiration from a hi
 
 ## Performance
 
-Local AppleClang microbenchmark sample (commit `eae8c0b`, collected 2026-06-11): Apple M4 Pro, macOS 26.5.1, AppleClang 21.0.0, Release/O3, Google Benchmark v1.9.5 (`BENCH_BITS=256 --gint_full --benchmark_min_time=0.2s`). Numbers are `real_time` ns/op (lower is better) for hot, in-cache operator throughput on fixed 256-bit inputs. Use them for same-toolchain regression tracking; Docker/GCC and real workload results should be reported separately.
+Local AppleClang microbenchmark sample (commit `3649c33b`, collected 2026-07-10): Apple M4 Pro, macOS 26.5.2, AppleClang 21.0.0, Release/O3, Google Benchmark v1.9.5 (`BENCH_BITS=256 --gint_full --benchmark_min_time=0.2s --benchmark_repetitions=3`). Numbers are median `real_time` ns/op (lower is better) for hot, in-cache operator throughput on fixed 256-bit inputs. The comparison matrix uses unsigned fixed-width types so every generated bit pattern maps to the same non-negative mathematical value in gint, ClickHouse, and Boost; native object layout remains library-specific. Use the results for same-toolchain regression tracking; Docker/GCC and real workload results should be reported separately.
 
 Arithmetic & ToString — 256-bit
 
 | Case                   | gint | ClickHouse | Boost |
 | ---------------------- | ---: | ---------: | ----: |
-| Add/NoCarry            | 0.666 |       1.11 |  4.37 |
-| Add/FullCarry          | 0.695 |       1.62 |  1.88 |
-| Sub/NoBorrow           | 0.691 |      0.944 |  4.38 |
-| Sub/FullBorrow         | 0.691 |       1.62 |  1.52 |
-| Mul/U64xU64            | 1.80 |       1.89 |  2.28 |
-| Mul/HighxHigh          | 1.83 |       2.79 | 11.5 |
-| Div/SmallDivisor32     | 10.8 |       14.0 | 20.2 |
-| Div/Pow2Divisor        | 4.85 |        310 | 67.4 |
-| Div/SimilarMagnitude   | 13.0 |        226 | 68.0 |
-| ToString/Base10        |  106 |        294 |  146 |
+| Add/NoCarry            | 0.672 |       1.02 |  3.05 |
+| Add/FullCarry          | 0.699 |       1.60 |  3.56 |
+| Sub/NoBorrow           | 0.697 |      0.960 |  4.40 |
+| Sub/FullBorrow         | 0.694 |       1.64 |  3.80 |
+| Mul/U64xU64            |  1.86 |       1.62 |  1.91 |
+| Mul/HighxHigh          |  1.82 |       1.60 |  10.7 |
+| Div/SmallDivisor32     |  8.61 |       11.4 |  19.0 |
+| Div/Pow2Divisor        |  3.14 |        316 |  64.3 |
+| Div/SimilarMagnitude   |  12.7 |        222 |  64.9 |
+| ToString/Base10        |   107 |        297 |   146 |
 
 Highlights
-- Add/Sub: faster than ClickHouse on the listed cases by ~1.4-2.3x, and faster than Boost by ~2.2-6.6x.
-- Mul: slightly faster on U64 x U64 and materially faster on high x high.
+- Add/Sub: faster than ClickHouse on the listed cases by ~1.4-2.4x, and faster than Boost by ~4.5-6.3x.
+- Mul: within ~2-15% of ClickHouse on the listed cases, and ~1.0-5.9x faster than Boost.
 - Div: large wins for power-of-two and similar-magnitude divisors; still faster on 32-bit small divisors.
 - ToString: ~1.4x faster vs Boost; ~2.8x vs ClickHouse.
 

--- a/bench/benchmark_int256.cpp
+++ b/bench/benchmark_int256.cpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstdlib>
+#include <iostream>
 #include <random>
 #include <string>
 #include <vector>
@@ -22,14 +23,19 @@ constexpr size_t kBenchBits = GINT_BENCH_BITS;
 static_assert(kBenchBits % 64 == 0, "benchmark widths must be limb-aligned");
 static_assert(kBenchBits >= 128, "benchmark widths must be at least 128 bits");
 
-using WInt = gint::integer<kBenchBits, signed>;
+// Keep the shared comparison matrix in one mathematical value domain. gint and
+// ClickHouse use two's-complement signed integers, while Boost's fixed signed
+// backend uses signed-magnitude. Feeding the same raw words to those signed
+// representations can therefore produce opposite signs. Unsigned fixed-width
+// types preserve the same non-negative value for every generated bit pattern.
+using WInt = gint::integer<kBenchBits, unsigned>;
 #ifdef GINT_ENABLE_CH_COMPARE
-using CInt = wide::integer<kBenchBits, signed>;
+using CInt = wide::integer<kBenchBits, unsigned>;
 #endif
 #ifdef GINT_ENABLE_BOOST_COMPARE
 using BInt = boost::multiprecision::number<
     boost::multiprecision::
-        cpp_int_backend<kBenchBits, kBenchBits, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, void>>;
+        cpp_int_backend<kBenchBits, kBenchBits, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>>;
 #endif
 
 inline std::string to_string_convert(const WInt & x)
@@ -85,6 +91,32 @@ inline Int random_wide_with_low_limb(std::mt19937_64 & rng, uint64_t low_limb)
         words[i] = rng();
     return assemble_words<Int>(words);
 }
+
+#if defined(GINT_ENABLE_CH_COMPARE) && defined(GINT_ENABLE_BOOST_COMPARE)
+bool comparison_values_match(const char * label, const std::array<uint64_t, kBenchLimbs> & words)
+{
+    const std::string gint_value = to_string_convert(assemble_words<WInt>(words));
+    const std::string clickhouse_value = to_string_convert(assemble_words<CInt>(words));
+    const std::string boost_value = to_string_convert(assemble_words<BInt>(words));
+    if (gint_value == clickhouse_value && gint_value == boost_value)
+        return true;
+
+    std::cerr << "comparison value-domain mismatch for " << label << ": gint=" << gint_value << ", ClickHouse=" << clickhouse_value
+              << ", Boost=" << boost_value << '\n';
+    return false;
+}
+
+bool verify_comparison_value_domain()
+{
+    std::array<uint64_t, kBenchLimbs> words{};
+    words[kBenchLimbs - 1] = uint64_t(1) << 63;
+    if (!comparison_values_match("top bit", words))
+        return false;
+
+    words.fill(~uint64_t(0));
+    return comparison_values_match("all bits set", words);
+}
+#endif
 
 } // namespace
 
@@ -151,7 +183,7 @@ static void Add_FullCarry(benchmark::State & state)
     {
         std::array<std::pair<Int, Int>, kDataN> d{};
         for (size_t i = 0; i < kDataN; ++i)
-            d[i] = {Int{-1}, Int{1}};
+            d[i] = {~Int{0}, Int{1}};
         return d;
     }();
     size_t i = 0;
@@ -733,6 +765,10 @@ static void Div_SimilarMagnitude2(benchmark::State & state)
 
 int main(int argc, char ** argv)
 {
+#if defined(GINT_ENABLE_CH_COMPARE) && defined(GINT_ENABLE_BOOST_COMPARE)
+    if (!verify_comparison_value_domain())
+        return 2;
+#endif
     bool full_matrix = parse_full_matrix_flag(argc, argv);
     // Addition
     REG_CASE("Add/NoCarry", Add_NoCarry);

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -10,15 +10,18 @@
 - 其他环境或编译器：使用独立 `runs/<scope>/` 和独立 `BENCH_BUILD_DIR`，例如本机 GCC、Linux GCC、Linux Clang 等。
 - 仓库内命令只假定已经位于当前执行环境；具体在哪里运行由外部编排决定。
 - 不同架构、OS、编译器结果应分别呈现，不直接混合横向比较。
+- 三方 comparison 矩阵统一使用 unsigned 固定位宽类型，使相同输入 bit pattern 在 gint、ClickHouse 与 Boost 中表示相同的非负数学值；benchmark 启动时会对最高位和全 1 边界值做三方一致性校验。
+- 各库保持自身原生对象布局，comparison 衡量的是实际库类型的 operator 吞吐，并不声称对象大小或内部表示已经归一化。
 - 可复现验证环境的初始化方式见 [验证环境固化](VALIDATION_ENVIRONMENTS.md)。该文档只固化当前环境依赖，不固定具体测试项目、过滤器或位宽。
 
-## 本机 AppleClang 样本（commit `eae8c0b`）
-- 采集时间：2026-06-11
-- 采集平台：Apple M4 Pro，macOS 26.5.1，arm64
+## 本机 AppleClang 样本（commit `3649c33b`）
+- 采集时间：2026-07-10
+- 采集平台：Apple M4 Pro，macOS 26.5.2，arm64
 - 核心数：12
 - 工具链：AppleClang 21.0.0，Google Benchmark v1.9.5
 - 编译：Release（`-O3 -DNDEBUG`）
-- 参数：`BENCH_BITS=256 --gint_full --benchmark_min_time=0.2s`
+- 参数：`BENCH_BITS=256 --gint_full --benchmark_min_time=0.2s --benchmark_repetitions=3`
+- 统计口径：3 次重复的 median `real_time`
 - 备注：macOS 上可能无法设置线程亲和性，Google Benchmark 的警告不影响相对对比。
 
 ## 通用提示
@@ -60,7 +63,7 @@
 ### 方法学
 - 每个用例 256 对确定性样本（固定种子），循环中轮询；
 - 三方库共享相同输入；
-- 对比测试只衡量吞吐，不校验三方结果等价；gint 正确性由单元测试覆盖；
+- 启动时校验三方输入在最高位和全 1 边界值上的数学值一致；计时循环不逐项比较运算结果，gint 正确性由单元测试覆盖；
 - 预生成数据集，循环内仅取引用与计算，不做拷贝/构造；
 - 对循环不变操作数与表达式使用 `benchmark::DoNotOptimize`，防止常量折叠或被外提；
 - 倾向覆盖常见“快/慢”路径与真实工作负载热点。
@@ -68,20 +71,20 @@
 
 ### 结果（完整矩阵，real_time ns/op）
 
-数值越低越好。以下数据来自 `bench-compare-full` 的本机 AppleClang 256-bit 样本（commit `eae8c0b`）；如需复现，应按上文命令重新采集当前工作区的本地结果。
+数值越低越好。以下数据来自 `bench-compare-full` 的本机 AppleClang 256-bit 样本（commit `3649c33b`），取 3 次重复的 median `real_time`；如需复现，应按上文命令重新采集当前工作区的本地结果。
 
 #### 加法（Addition）
 
 **设计**
 - NoCarry：低位进位概率低，覆盖“无跨 limb 进位”的最快路径。
-- FullCarry：-1 + 1，覆盖“全链条进位”最坏路径。
+- FullCarry：全 1 位模式 + 1，覆盖“全链条进位”最坏路径。
 - CarryChain64：仅低 64 位形成进位链，隔离低层 carry 传播。
 
 | 用例         | gint  | ClickHouse | Boost |
 | ------------ | ----: | ---------: | ----: |
-| NoCarry      | 0.666 |       1.11 |  4.37 |
-| FullCarry    | 0.695 |       1.62 |  1.88 |
-| CarryChain64 | 0.688 |       1.15 |  4.33 |
+| NoCarry      | 0.672 |       1.02 |  3.05 |
+| FullCarry    | 0.699 |       1.60 |  3.56 |
+| CarryChain64 | 0.699 |       1.17 |  3.37 |
 
 #### 减法（Subtraction）
 
@@ -92,9 +95,9 @@
 
 | 用例          | gint  | ClickHouse | Boost |
 | ------------- | ----: | ---------: | ----: |
-| NoBorrow      | 0.691 |      0.944 |  4.38 |
-| FullBorrow    | 0.691 |       1.62 |  1.52 |
-| BorrowChain64 | 0.690 |       1.18 |  4.15 |
+| NoBorrow      | 0.697 |      0.960 |  4.40 |
+| FullBorrow    | 0.694 |       1.64 |  3.80 |
+| BorrowChain64 | 0.697 |       1.17 |  4.24 |
 
 #### 乘法（Multiplication）
 
@@ -106,10 +109,10 @@
 
 | 用例         | gint  | ClickHouse | Boost |
 | ------------ | ----: | ---------: | ----: |
-| U64xU64      | 1.80 |       1.89 |  2.28 |
-| HighxHigh    | 1.83 |       2.79 |  11.5 |
-| WideTimesU64 | 1.53 |       3.29 |  2.52 |
-| U32xWide     | 1.80 |       2.40 |  3.65 |
+| U64xU64      | 1.86 |       1.62 |  1.91 |
+| HighxHigh    | 1.82 |       1.60 |  10.7 |
+| WideTimesU64 | 0.916 |      0.892 |  1.82 |
+| U32xWide     | 1.83 |       1.60 |  2.84 |
 
 #### 除法（Division）
 
@@ -123,12 +126,12 @@
 
 | 用例                       | gint | ClickHouse | Boost |
 | -------------------------- | ---: | ---------: | ----: |
-| SmallDivisor32（32 位）    | 10.8 |       14.0 |  20.2 |
-| SmallDivisor64（64 位）    | 13.5 |       13.5 |  21.9 |
-| Pow2Divisor（2 的幂）      | 4.85 |        310 |  67.4 |
-| SimilarMagnitude           | 13.0 |        226 |  68.0 |
-| LargeDivisor128（两 limb） | 18.1 |        546 |  37.1 |
-| SimilarMagnitude2          | 9.91 |        208 |  81.7 |
+| SmallDivisor32（32 位）    | 8.61 |       11.4 |  19.0 |
+| SmallDivisor64（64 位）    | 12.6 |       13.1 |  21.1 |
+| Pow2Divisor（2 的幂）      | 3.14 |        316 |  64.3 |
+| SimilarMagnitude           | 12.7 |        222 |  64.9 |
+| LargeDivisor128（两 limb） | 16.5 |        547 |  34.2 |
+| SimilarMagnitude2          | 9.72 |        206 |  80.0 |
 
 #### 取模（Modulo）
 
@@ -138,8 +141,8 @@
 
 | 用例             | gint | ClickHouse | Boost |
 | ---------------- | ---: | ---------: | ----: |
-| SmallDivisor64   | 11.7 |       15.0 |  20.5 |
-| SimilarMagnitude | 16.7 |        227 |  67.5 |
+| SmallDivisor64   | 12.0 |       14.8 |  20.1 |
+| SimilarMagnitude | 16.6 |        226 |  67.1 |
 
 #### 位运算（Bitwise）
 
@@ -149,8 +152,8 @@
 
 | 用例 | gint  | ClickHouse | Boost |
 | ---- | ----: | ---------: | ----: |
-| And  | 0.364 |      0.379 |  6.57 |
-| Xor  | 0.360 |      0.430 |  7.07 |
+| And  | 0.370 |      0.384 |  5.14 |
+| Xor  | 0.371 |      0.385 |  4.92 |
 
 #### 移位（Shift）
 
@@ -160,8 +163,8 @@
 
 | 用例          | gint | ClickHouse | Boost |
 | ------------- | ---: | ---------: | ----: |
-| LeftVariable  | 1.31 |       3.36 |  5.67 |
-| RightVariable | 1.35 |       3.07 |  3.26 |
+| LeftVariable  | 1.44 |       3.34 |  6.50 |
+| RightVariable | 1.39 |       1.87 |  2.52 |
 
 #### 字符串转换（ToString）
 
@@ -170,4 +173,4 @@
 
 | 用例   | gint | ClickHouse | Boost |
 | ------ | ---: | ---------: | ----: |
-| Base10 |  106 |        294 |   146 |
+| Base10 |  107 |        297 |   146 |


### PR DESCRIPTION
## 问题

- 现象：三方 comparison 将同一组 raw words 直接装配为 signed 类型；最高位为 1 时，gint/ClickHouse 的补码值为负数，而 Boost fixed signed-magnitude 的值为正数，导致部分用例实际比较不同数学值和不同运算路径。
- 根因：benchmark 把“相同位模式”误当成“相同数学值”，没有处理补码与 signed-magnitude 的表示差异。各库原生对象布局本就不同，也不应被描述为已归一化。

## 做了什么

- 将共享 comparison 矩阵统一为 unsigned 固定位宽类型，使全部输入 bit pattern 在三方表示相同非负数学值。
- 将 FullCarry 显式改为“全 1 位模式 + 1”，避免依赖 signed 的 `-1` 构造语义。
- 在 comparison 启动时校验最高位与全 1 两个边界输入；三方十进制值不一致时立即失败。
- 更新 benchmark 规范、方法说明与修复后 AppleClang 256-bit 数据，并明确各库仍使用原生对象布局。
- 纠正旧样本造成的结论偏差：例如 Boost FullCarry median 从旧口径约 1.84 ns 变为同值口径 3.56 ns，FullBorrow 从约 1.53 ns 变为 3.80 ns。

## 验证

- `clang-format` 与 `git diff --check` 通过。
- 普通测试：451/451 通过。
- ASan/UBSan：238/238 通过。
- Int128/Int256/Int512/Int1024 comparison 均完成构建并通过启动值域校验；完整矩阵各注册 69 个用例。
- AppleClang 21.0.0、Google Benchmark v1.9.5、256-bit 完整 comparison（`--benchmark_min_time=0.2s --benchmark_repetitions=3`）采集完成，文档使用 median `real_time`。

## 风险

- comparison 从 signed 切换为 unsigned，修复前后的历史三方数据不能直接作回归比较；本 PR 已刷新公开样本。
- 各库对象大小和内部布局仍保持原生实现；本 comparison 对齐数学值并衡量 operator 吞吐，不用于比较内存占用。