### PR TITLE
feat: publish coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
@@ -186,6 +189,14 @@ jobs:
         with:
           name: coverage-info
           path: runs/ci/coverage.info
+      - name: Publish coverage to Codecov
+        if: github.ref == 'refs/heads/main'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: runs/ci/coverage.info
+          disable_search: true
+          fail_ci_if_error: false
+          use_oidc: true
 
   sanitizers:
     name: sanitizers (ubuntu-clang)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gint
 
 [![CI](https://github.com/KodiakAS/gint/actions/workflows/ci.yml/badge.svg)](https://github.com/KodiakAS/gint/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/KodiakAS/gint/branch/main/graph/badge.svg)](https://app.codecov.io/gh/KodiakAS/gint)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 `gint` is a performance-first, header-only C++11 library for exact-width wide


### PR DESCRIPTION
## 概述

- 在 README 中展示 `main` 分支的动态代码覆盖率标签。
- 将现有 coverage job 生成的 LCOV 报告发布到 Codecov。

## 做了什么

- 保留现有覆盖率构建、测试和 artifact 上传步骤。
- 仅在 `main` 分支通过 OIDC 上传覆盖率，不新增仓库 Secret。
- 将 Codecov 上传设为非阻塞，外部服务故障不会改变原有 CI 结果。
- 将 Codecov Action 固定到 v7.0.0 对应的不可变提交。
- 在 README 的现有徽章区增加 Codecov 标签。

## API / 行为

- 不修改 gint 公共 API、算术行为、构建产物或支持矩阵。
- 不修改任何现有测试命令和测试门禁。

## 验证

- `actionlint 1.7.12`
- `git diff --check`
- GitHub Actions YAML 解析
- Codecov badge 和项目链接可访问

## 兼容性与风险

- 覆盖率仅在 `main` 分支发布，PR 测试流程保持不变。
- 标签会在首次成功上传后由 `unknown` 更新为实际覆盖率。
